### PR TITLE
Changed $excel from protected to public.

### DIFF
--- a/src/Maatwebsite/Excel/Excel.php
+++ b/src/Maatwebsite/Excel/Excel.php
@@ -118,7 +118,7 @@ class Excel extends \PHPExcel
         $this->excel = $this->reader->load($this->file);
 
         // Return itself
-        return $this
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This enables chaining methods from `PHPExcel` itself.

Example:

```
$obj = Excel::load('temp1.xls'); // Has some contents inside
$obj->excel->getActiveSheet()->setCellValue('F2', 'testing');  // use the excel object to call getActiveSheet
$obj->export('xls'); // export as usual
```
