### PR TITLE
Feature: Can set input encoding when loading csv file

### DIFF
--- a/src/Maatwebsite/Excel/Excel.php
+++ b/src/Maatwebsite/Excel/Excel.php
@@ -104,7 +104,7 @@ class Excel extends \PHPExcel
      *
      */
 
-    public function load($file, $firstRowAsLabel = false)
+    public function load($file, $firstRowAsLabel = false, $inputEncoding = 'UTF-8')
     {
 
         // Set defaults
@@ -117,7 +117,7 @@ class Excel extends \PHPExcel
         $this->format = \PHPExcel_IOFactory::identify($this->file);
 
         // Init the reader
-        $this->reader = \PHPExcel_IOFactory::createReader($this->format);
+        $this->reader = \PHPExcel_IOFactory::createReader($this->format)->setInputEncoding($inputEncoding);
 
         // Set default delimiter
         //$this->reader->setDelimiter($this->delimiter);


### PR DESCRIPTION
This problem solves the problem when reading `Ñ` or `ñ` from a csv file.

Usage::

```
Excel::load('file.csv', false, 'cp1250');
```

The default input encoding is `UTF-8`.
