### PR TITLE
Feature: Can set input encoding when loading csv file

### DIFF
--- a/src/Maatwebsite/Excel/Excel.php
+++ b/src/Maatwebsite/Excel/Excel.php
@@ -117,7 +117,10 @@ class Excel extends \PHPExcel
         $this->format = \PHPExcel_IOFactory::identify($this->file);
 
         // Init the reader
-        $this->reader = \PHPExcel_IOFactory::createReader($this->format)->setInputEncoding($inputEncoding);
+        $this->reader = \PHPExcel_IOFactory::createReader($this->format);
+
+        if ($this->format === 'CSV')
+            $this->reader->setInputEncoding($inputEncoding);
 
         // Set default delimiter
         //$this->reader->setDelimiter($this->delimiter);


### PR DESCRIPTION
Usage:

```
$data = Excel::load('file.csv', false, 'ISO-8859-1');
```

This solves the problem when reading `Ñ` or `ñ`.
