### PR TITLE
Undefined Offset when parsing cells

### DIFF
--- a/src/Maatwebsite/Excel/Parsers/ExcelParser.php
+++ b/src/Maatwebsite/Excel/Parsers/ExcelParser.php
@@ -254,7 +254,7 @@ class ExcelParser {
         foreach ($cellIterator as $this->cell) {
 
             // Check how we need to save the parsed array
-            $index = $this->reader->hasHeading() ? $this->indices[$i] : $this->getIndexFromColumn();
+            $index = ($this->reader->hasHeading() && isset($this->indices[$i])) ? $this->indices[$i] : $this->getIndexFromColumn();
 
             // Check if we want to select this column
             if($this->cellNeedsParsing($index) )


### PR DESCRIPTION
Seems like the parser sometimes gets "trigger happy"  I parsing some excel sheets -- it tries to parse an index that doesn't exist which leads to an "Undefined Offset"
