### PR TITLE
Modified setBorder() in CellWriter.php

### DIFF
--- a/src/Maatwebsite/Excel/Writers/CellWriter.php
+++ b/src/Maatwebsite/Excel/Writers/CellWriter.php
@@ -135,19 +135,17 @@ class CellWriter {
     {
         // Set the border styles
         $styles = is_array($top) ? $top : array(
-            'borders' => array(
-                'top'   => array(
-                    'style' => $top
-                ),
-                'left' => array(
-                    'style' => $left,
-                ),
-                'right' => array(
-                    'style' => $right,
-                ),
-                'bottom' => array(
-                    'style' => $bottom,
-                )
+            'top'   => array(
+                'style' => $top
+            ),
+            'left' => array(
+                'style' => $left,
+            ),
+            'right' => array(
+                'style' => $right,
+            ),
+            'bottom' => array(
+                'style' => $bottom,
             )
         );
 


### PR DESCRIPTION
Modified `setBorder()` so that 'top', 'left', etc. are moved up one position in the array that is passed to `setStyle()`.

`setStyle()` just directly passes the $styles to `PHPExcel_Style_Borders::applyFromArray()` which looks for `$styles['left']`, not `$styles['borders']['left']`.

Calling something like 

```
$excel->row(1, function($row) {
    $row->setFontSize(14)
        ->setFontWeight('bold')
        ->setBorder('none', 'none', 'thin', 'none');
});
```

previously would not apply any border because it would pass `$styles['borders']['top'] = 'none'` instead of `$styles['top'] = 'none'`.
