### PR TITLE
Fixed a variable name in code documentation

### DIFF
--- a/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
+++ b/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
@@ -185,7 +185,7 @@ class LaravelExcelReader {
     /**
      * Load a file
      * @param  string  $file
-     * @param  boolean $firstRowAsIndex
+     * @param  string|boolean $encoding
      * @return LaravelExcelReader
      */
     public function load($file, $encoding = false)
@@ -468,7 +468,7 @@ class LaravelExcelReader {
     /**
      * Init the loading
      * @param  string $file
-     * @param  string|boolean $firstRowAsIndex
+     * @param  string|boolean $encoding
      * @return void
      */
     protected function _init($file, $encoding = false)


### PR DESCRIPTION
Changed `$firstRowAsIndex` to `$encoding` in code documentation for `_init` and `load` functions
