### PR TITLE
Add PDF Support fixes #261 Note, chart output is not enabled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "illuminate/routing": "~4.0|~5.0",
         "illuminate/view": "~4.0|~5.0",
         "nesbot/carbon": "~1.0",
-        "tijsverkoyen/css-to-inline-styles": "~1.5"
+        "tijsverkoyen/css-to-inline-styles": "~1.5",
+        "dompdf/dompdf": "0.6.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Maatwebsite/Excel/Classes/FormatIdentifier.php
+++ b/src/Maatwebsite/Excel/Classes/FormatIdentifier.php
@@ -21,6 +21,7 @@ class FormatIdentifier {
         'Gnumeric',
         'CSV',
         'HTML',
+        'PDF'
     );
 
     /**
@@ -148,9 +149,9 @@ class FormatIdentifier {
             | PDF
             |--------------------------------------------------------------------------
             */
-            // case 'pdf':
-            //     return 'PDF';
-            //     break;
+             case 'pdf':
+                 return 'PDF';
+                 break;
         }
     }
 
@@ -205,9 +206,9 @@ class FormatIdentifier {
             | PDF
             |--------------------------------------------------------------------------
             */
-            // case 'PDF':
-            //     return'application/pdf; charset=UTF-8';
-            //     break;
+             case 'PDF':
+                 return'application/pdf; charset=UTF-8';
+                 break;
         }
     }
 

--- a/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
+++ b/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
@@ -466,6 +466,22 @@ class LaravelExcelWriter {
      */
     protected function _setWriter()
     {
+        if ($this->format == 'PDF')
+        {
+            // Setup the renderer
+            $rendererName = \PHPExcel_Settings::PDF_RENDERER_DOMPDF;
+            $rendererLibraryPath = __DIR__.'/../../../../../../dompdf/dompdf/';
+            // DOMPDF can't be allowed to autoload with composer which we must be using since this is Laravel...
+            define("DOMPDF_ENABLE_AUTOLOAD", false);
+
+            if (!\PHPExcel_Settings::setPdfRenderer(
+                $rendererName,
+                $rendererLibraryPath
+            )) {
+                throw new \Exception("PDF Path is incorrect.  Composer must have put dompdf elsewhere.");
+            }
+        }
+        
         $this->writer = PHPExcel_IOFactory::createWriter($this->excel, $this->format);
 
         // Set CSV delimiter


### PR DESCRIPTION
The PDF output isn't the best because PHPExcel does an HTML output and then runs that through the pdf libraries html input and PDF libraries and tables have never gotten along great...  But it does work.

To use charts a chart render library would need to be installed and enabled.  JPGraph is proprietary so I couldn't build it in.

``` php
$rendererName = PHPExcel_Settings::CHART_RENDERER_JPGRAPH;
$rendererLibrary = 'jpgraph3.5.0b1/src';
$rendererLibraryPath = '/php/libraries/Charts/' . $rendererLibrary;


if (!PHPExcel_Settings::setChartRenderer(
        $rendererName,
        $rendererLibraryPath
    )) {
    die(
        'NOTICE: Please set the $rendererName and $rendererLibraryPath values' .
        EOL .
        'at the top of this script as appropriate for your directory structure'
    );
}
```
