### PR TITLE
Fix bug for Laravel 4.0

### DIFF
--- a/src/Maatwebsite/Excel/ExcelServiceProvider.php
+++ b/src/Maatwebsite/Excel/ExcelServiceProvider.php
@@ -97,7 +97,7 @@ class ExcelServiceProvider extends ServiceProvider {
     protected function bindCssParser()
     {
         // Bind css parser
-        $this->app->bindShared('excel.parsers.css', function ($app)
+        $this->app['excel.parsers.css'] = $this->app->share(function ($app)
         {
             return new CssParser(new CssToInlineStyles());
         });


### PR DESCRIPTION
A simple fix for Laravel 4.0. The function ->bindShared() doesn't exist in 4.0. This fix fixes my problems in my 4.0 environment.