### PR TITLE
Added ability to get heading not only from first row

### DIFF
--- a/src/Maatwebsite/Excel/Parsers/ExcelParser.php
+++ b/src/Maatwebsite/Excel/Parsers/ExcelParser.php
@@ -93,6 +93,9 @@ class ExcelParser {
     {
         $this->reader = $reader;
         $this->excel = $reader->excel;
+        
+        //Change first row
+        $this->defaultStartRow = $this->currentRow = Config::get('excel::import.startRow', 1);
 
         // Reset
         $this->reset();
@@ -186,8 +189,8 @@ class ExcelParser {
      */
     protected function getIndices()
     {
-        // Fetch the first row
-        $this->row = $this->worksheet->getRowIterator(1)->current();
+        // Fetch the first row or row with heading(from config)
+        $this->row = $this->worksheet->getRowIterator($this->defaultStartRow)->current();
 
         // Set empty labels array
         $this->indices = array();

--- a/src/config/import.php
+++ b/src/config/import.php
@@ -14,6 +14,18 @@ return array(
     */
 
     'heading'                 => 'slugged',
+    
+    /*
+    |--------------------------------------------------------------------------
+    | First Row with data or heading of data
+    |--------------------------------------------------------------------------
+    |
+    | If heading row not first we can change this option to current heading row.
+    | It changes and the first data row, so we don't need to use ->skip() method
+    |
+    */
+
+    'startRow'                 => 1,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
If data begins not from first row and there is something that prepend data and we want to skip it, we can change option excel::import.startRow to our first row with data or heading.