### PR TITLE
Add inline formatting to cells in blade

### DIFF
--- a/src/Maatwebsite/Excel/Readers/HtmlReader.php
+++ b/src/Maatwebsite/Excel/Readers/HtmlReader.php
@@ -316,7 +316,12 @@ class Html extends PHPExcel_Reader_HTML {
                         case 'valign':
                             $this->parseValign($sheet, $column, $row, $attribute->value);
                             break;
-
+                        
+                        // Cell format
+                        case 'data-format':
+                            $this->parseDataFormat($sheet, $column, $row, $attribute->value);
+                            break;
+                            
                         // Inline css styles
                         case 'style':
                             $this->parseInlineStyles($sheet, $column, $row, $attribute->value);
@@ -768,6 +773,19 @@ class Html extends PHPExcel_Reader_HTML {
         $this->parseHeight($sheet, $column, $row, $drawing->getHeight());
     }
 
+    /**
+     * Set cell data format
+     * @param  LaravelExcelWorksheet $sheet
+     * @param  string                $column
+     * @param  integer               $row
+     * @param  integer               $width
+     * @return void
+     */
+    protected function parseDataFormat($sheet, $column, $row, $format)
+    {
+        $sheet->setColumnFormat([$column.$row => $format]);
+    }
+    
     /**
      * Set column width
      * @param  LaravelExcelWorksheet $sheet


### PR DESCRIPTION
Format table cells with "data-format" attribute and value from docs/reference-guide/formatting.  

**Example:**
```
<td data-format="$#,##0_-">Currency USD</td>
<td data-format="0%">Percentage</td>
<td data-format="dd/mm/yy">Date</td>
<td data-format="h:mm:ss AM/PM">Date/Time</td>
```