### PR TITLE
Add inline cell formatting to blade

### DIFF
--- a/src/Maatwebsite/Excel/Readers/HtmlReader.php
+++ b/src/Maatwebsite/Excel/Readers/HtmlReader.php
@@ -317,6 +317,11 @@ class Html extends PHPExcel_Reader_HTML {
                             $this->parseValign($sheet, $column, $row, $attribute->value);
                             break;
 
+                        // Cell format
+                        case 'data-format':
+                            $this->parseDataFormat($sheet, $column, $row, $attribute->value);
+                            break;
+
                         // Inline css styles
                         case 'style':
                             $this->parseInlineStyles($sheet, $column, $row, $attribute->value);
@@ -766,6 +771,19 @@ class Html extends PHPExcel_Reader_HTML {
         // Set cell width based on image
         $this->parseWidth($sheet, $column, $row, $drawing->getWidth() / 3);
         $this->parseHeight($sheet, $column, $row, $drawing->getHeight());
+    }
+
+    /**
+     * Set cell data format
+     * @param  LaravelExcelWorksheet $sheet
+     * @param  string                $column
+     * @param  integer               $row
+     * @param  integer               $width
+     * @return void
+    */
+    protected function parseDataFormat($sheet, $column, $row, $format)
+    {
+        $sheet->setColumnFormat([$column.$row => $format]);
     }
 
     /**


### PR DESCRIPTION
Format table cells with "data-format" attribute and value from docs/reference-guide/formatting.  

**Example:**
```
<td data-format="$#,##0_-">Currency USD</td>
<td data-format="0%">Percentage</td>
<td data-format="dd/mm/yy">Date</td>
<td data-format="h:mm:ss AM/PM">Date/Time</td>
```