### PR TITLE
Update composer.json to lock phpexcel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "phpoffice/phpexcel": "~1.8.0",
+        "phpoffice/phpexcel": "1.8.0",
         "illuminate/cache": "~4.0|~5.0",
         "illuminate/config": "~4.0|~5.0",
         "illuminate/filesystem": "~4.0|~5.0",


### PR DESCRIPTION
Regarding issue #417 updating to 1.8.1 breaks as `setLineEnding` has been removed