### PR TITLE
Check if Dom_PDF is defined

### DIFF
--- a/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
+++ b/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
@@ -539,7 +539,9 @@ class LaravelExcelWriter {
         $path = Config::get('excel.export.pdf.drivers.' . $driver . '.path');
 
         // Disable autoloading for dompdf
-        define("DOMPDF_ENABLE_AUTOLOAD", false);
+        if(! defined("DOMPDF_ENABLE_AUTOLOAD")){
+            define("DOMPDF_ENABLE_AUTOLOAD", false);
+        }
 
         // Set the pdf renderer
         if (!\PHPExcel_Settings::setPdfRenderer($driver, $path))


### PR DESCRIPTION
If it's not, we define it. It avoids conflict if DOM_PDF is already defined.