### PR TITLE
Start index fix for no heading documents in chunk method.

### DIFF
--- a/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
+++ b/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
@@ -556,8 +556,8 @@ class LaravelExcelReader
         for ($startRow = 0; $startRow < $totalRows; $startRow += $chunkSize) {
 
             // Set start index
-            $startIndex = ($startRow == 0) ? $startRow : $startRow - 1;
-            $chunkSize  = ($startRow == 0) ? $size + 1 : $size;
+            $startIndex = ($startRow == 0 || !$this->hasHeading()) ? $startRow : $startRow - 1;
+            $chunkSize  = ($startRow == 0 || $this->hasHeading()) ? $size + 1 : $size;
 
             $job = new ChunkedReadJob(
                 $this->file,


### PR DESCRIPTION
If import document without heading using chunk method will get duplicate of the row with number equal chunk size and the last row will be escaped.
