### PR TITLE
Added an explicit row manipulation methods

### DIFF
--- a/src/Maatwebsite/Excel/Classes/LaravelExcelWorksheet.php
+++ b/src/Maatwebsite/Excel/Classes/LaravelExcelWorksheet.php
@@ -173,9 +173,10 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
      * Manipulate a single row
      * @param  integer|callback|array $rowNumber
      * @param  array|callback         $callback
+     * @param  boolean                $explicit
      * @return LaravelExcelWorksheet
      */
-    public function row($rowNumber, $callback = null)
+    public function row($rowNumber, $callback = null, $explicit = false)
     {
         // If a callback is given, handle it with the cell writer
         if ($callback instanceof Closure)
@@ -200,7 +201,11 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
                 $cell = $column . $rowNumber;
 
                 // Set the cell value
-                $this->setCellValue($cell, $rowValue);
+                if ($explicit) {
+                    $this->setCellValueExplicit($cell, $rowValue);
+                } else {
+                    $this->setCellValue($cell, $rowValue);
+                }
                 $column++;
             }
         }
@@ -214,9 +219,10 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
     /**
      * Add multiple rows
      * @param  array $rows
+     * @param  boolean $explicit
      * @return LaravelExcelWorksheet
      */
-    public function rows($rows = array())
+    public function rows($rows = array(), $explicit = false)
     {
         // Get the start row
         $startRow = $this->getStartRow();
@@ -224,7 +230,7 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
         // Add rows
         foreach ($rows as $row)
         {
-            $this->row($startRow, $row);
+            $this->row($startRow, $row, $explicit);
             $startRow++;
         }
 
@@ -235,9 +241,10 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
      * Prepend a row
      * @param  integer        $rowNumber
      * @param  array|callback $callback
+     * @param  boolean        $explicit
      * @return LaravelExcelWorksheet
      */
-    public function prependRow($rowNumber = 1, $callback = null)
+    public function prependRow($rowNumber = 1, $callback = null, $explicit = false)
     {
         // If only one param was given, prepend it before the first row
         if (is_null($callback))
@@ -250,16 +257,28 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
         $this->insertNewRowBefore($rowNumber);
 
         // Add data to row
-        return $this->row($rowNumber, $callback);
+        return $this->row($rowNumber, $callback, $explicit);
+    }
+
+    /**
+     * Prepend a row explicitly
+     * @param  integer        $rowNumber
+     * @param  array|callback $callback
+     * @return LaravelExcelWorksheet
+     */
+    public function prependRowExplicit($rowNumber = 1, $callback = null)
+    {
+        return $this->prependRow($rowNumber, $callback, true);
     }
 
     /**
      * Append a row
      * @param  integer|callback $rowNumber
      * @param  array|callback   $callback
+     * @param  boolean          $explicit
      * @return LaravelExcelWorksheet
      */
-    public function appendRow($rowNumber = 1, $callback = null)
+    public function appendRow($rowNumber = 1, $callback = null, $explicit = false)
     {
         // If only one param was given, add it as very last
         if (is_null($callback))
@@ -269,24 +288,41 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
         }
 
         // Add the row
-        return $this->row($rowNumber, $callback);
+        return $this->row($rowNumber, $callback, $explicit);
+    }
+
+    /**
+     * Append a row explicitly
+     * @param  integer|callback $rowNumber
+     * @param  array|callback   $callback
+     * @return LaravelExcelWorksheet
+     */
+    public function appendRowExplicit($rowNumber = 1, $callback = null)
+    {
+        return $this->appendRow($rowNumber, $callback, true);
     }
 
     /**
      * Manipulate a single cell
      * @param  array|string $cell
      * @param bool|callable $callback $callback
+     * @param       boolean $explicit
      * @return LaravelExcelWorksheet
      */
-    public function cell($cell, $callback = false)
+    public function cell($cell, $callback = false, $explicit = false)
     {
         // If a callback is given, handle it with the cell writer
         if ($callback instanceof Closure)
             return $this->cells($cell, $callback);
 
         // Else if the 2nd param was set, we will use it as a cell value
-        if ($callback)
-            $this->setCellValue($cell, $callback);
+        if ($callback) {
+            if ($explicit) {
+                $this->setCellValueExplicit($cell, $callback);
+            } else {
+                $this->setCellValue($cell, $callback);
+            }
+        }
 
         return $this;
     }


### PR DESCRIPTION
PR includes some new methods that should solve a problem when trying to export data with strings that start with "= sign". It is also an old problem described in: #164 .

Below is a workaround that works using `setCellValueExplicit` method:

``` php
        $languages = ['EN', 'NL', 'FR', 'ES', 'PT', 'DE', 'IT', 'RU'];
        $query = "....";

        $excel = Excel::create('translations');
        $excel->sheet('Sheet 1', function($sheet) use ($languages, $query) {
            $pdo = DB::connection()->getPdo();
            $pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
            $results = $pdo->query($query);

            $rowIndex = 0;
            while ($row = $results->fetch(PDO::FETCH_ASSOC)) {
                 $rowIndex++;
                 $columnIndex = 'A';

                 $sheet->setCellValueExplicit("{$columnIndex}{$rowIndex}", $row['interface_string_id']);
                 $columnIndex++;

                 foreach ($languages as $language) {
                      $sheet->setCellValueExplicit("{$columnIndex}{$rowIndex}", $row["{$language}_language_string"]);
                      $columnIndex++;
                 }

                 $rowIndex++;
            }
        });

        $excel->download();
```

Instead of writing an above code and after newly added methods, it is now as simple as:

``` php
        // ..................
        while ($row = $results->fetch(PDO::FETCH_ASSOC)) {
              $sheet->appendRowExplicit($row);
        }
```

To be honest, it's a very basic implementation and default dataType used for the cell is `PHPExcel_Cell_DataType::TYPE_STRING`. In the future it could be extended to allow other PHPExcel_Cell_DataType attributes for different cells.

Looking forward!
