### PR TITLE
Support for text-indent value

### DIFF
--- a/src/Maatwebsite/Excel/Readers/HtmlReader.php
+++ b/src/Maatwebsite/Excel/Readers/HtmlReader.php
@@ -1229,7 +1229,7 @@ class Html extends PHPExcel_Reader_HTML {
                 break;
 
             case 'text-indent':
-                $cells->getAlignment()->setIndent(1);
+                $cells->getAlignment()->setIndent((int)$value);
                 break;
         }
     }


### PR DESCRIPTION
Support for the text-indent property was added to resolve #314, but it will always set indent to 1, regardless of the actual value.

The proposed would take the text-indent value and apply that, allowing for varying degrees of text indents.
