### PR TITLE
Update README.md with Laravel 5.2 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,29 @@ Require this package in your `composer.json` and update composer. This will down
 "maatwebsite/excel": "~2.1.0"
 ```
 
+For Laravel 5.2 use you have to install the [laravelcollective/bus](https://laravelcollective.com/docs/5.2/bus#installation) package. 
+Add this to the `composer.json` and update composer:
+
+```php
+"laravelcollective/bus": "^5.2"
+```
+
+Then add the following lines to the `config/app.php`:
+
+```php
+'providers' => [
+    // ...
+    Collective\Bus\BusServiceProvider::class,
+    // ...
+  ],
+  
+  'aliases' => [
+    // ...
+    'Illuminate\Bus\Dispatcher' => Collective\Bus\Dispatcher::class,
+    // ...
+  ],
+```
+
 After updating composer, add the ServiceProvider to the providers array in `config/app.php`
 
 ```php


### PR DESCRIPTION
Added missing Laravel 5.2 install instructions to the README.md
