### PR TITLE
Update namespaces

### DIFF
--- a/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
+++ b/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
@@ -1,7 +1,7 @@
 <?php namespace Maatwebsite\Excel\Readers;
 
-use Cache;
-use Config;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Facades\Queue;
 use Maatwebsite\Excel\Classes\PHPExcel;


### PR DESCRIPTION
While I'm using Laravel and Lumen, it couldn't find those classes in Lumen because of the wrong import (Laravel only).
This will make sure we are importing from the correct namespace and will work both on Laravel and Lumen.
