### PR TITLE
Use facade class instead of actual facade

### DIFF
--- a/src/Maatwebsite/Excel/ExcelServiceProvider.php
+++ b/src/Maatwebsite/Excel/ExcelServiceProvider.php
@@ -7,6 +7,7 @@ use Maatwebsite\Excel\Classes\Cache;
 use Illuminate\Support\Facades\Config;
 use Maatwebsite\Excel\Classes\PHPExcel;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Response;
 use Maatwebsite\Excel\Parsers\CssParser;
 use Maatwebsite\Excel\Parsers\ViewParser;
 use Maatwebsite\Excel\Classes\FormatIdentifier;
@@ -158,7 +159,7 @@ class ExcelServiceProvider extends ServiceProvider {
         $this->app['excel.writer'] = $this->app->share(function ($app)
         {
             return new LaravelExcelWriter(
-                $app->make('Response'),
+                $app->make(Response::class),
                 $app['files'],
                 $app['excel.identifier']
             );


### PR DESCRIPTION
This is better because now we're not relying on user land code. Facades can be removed/changed from the config file while the actual facade class doesn't.

Still, in a future version, the facades used in this library should be replaced by actual implementations/contracts which Laravel offers.
