### PR TITLE
Move TestCase.php to autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,15 @@
   },
   "autoload": {
     "classmap": [
-      "src/Maatwebsite/Excel",
-      "tests/TestCase.php"
+      "src/Maatwebsite/Excel"
     ],
     "psr-0": {
       "Maatwebsite\\Excel\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "classmap": [
+      "tests/TestCase.php"
+    ],
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,6 @@
   "autoload-dev": {
     "classmap": [
       "tests/TestCase.php"
-    ],
+    ]
   }
 }


### PR DESCRIPTION
Since the TestCase.php is a file only needed for development installs, I wanted to move this to the autoload-dev.
