### PR TITLE
Fix data being shifted when ignoreEmpty is set and cells in between o…

### DIFF
--- a/src/Maatwebsite/Excel/Parsers/ExcelParser.php
+++ b/src/Maatwebsite/Excel/Parsers/ExcelParser.php
@@ -426,7 +426,6 @@ class ExcelParser {
      */
     protected function parseCells()
     {
-        $i = 0;
         $parsedCells = array();
 
         try {
@@ -440,7 +439,11 @@ class ExcelParser {
             foreach ($cellIterator as $this->cell)
             {
                 // Check how we need to save the parsed array
-                $index = ($this->reader->hasHeading() && isset($this->indices[$i])) ? $this->indices[$i] : $this->getIndexFromColumn();
+                // Use the index from column as the initial position
+                // Or else PHPExcel skips empty cells (even between non-empty) cells and it will cause
+                // data to end up in the result object
+                $index = $this->getIndexFromColumn() - 1;
+                $index = ($this->reader->hasHeading() && isset($this->indices[$index])) ? $this->indices[$index] : $index;
 
                 // Check if we want to select this column
                 if ( $this->cellNeedsParsing($index) )
@@ -448,8 +451,6 @@ class ExcelParser {
                     // Set the value
                     $parsedCells[$index] = $this->parseCell($index);
                 }
-
-                $i++;
             }
 
         } catch (PHPExcel_Exception $e) {


### PR DESCRIPTION
Fix issue #742  I opened earlier....

ignoreEmpty() will skip all cells that are empty, even those in between non-empty cells. That works fine up until you notice all your data in the result object is shifted because it was using a for loop with manual iterator. This just uses the column index as the primary index (which will always be correct if a cell is skipped).
