### PR TITLE
Update `Orchestra/TestBench` dependency for Laravel 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "phpseclib/phpseclib": "~1.0",
     "phpunit/phpunit": "~4.0",
     "mockery/mockery": "~0.9",
-    "orchestra/testbench": "3.1.*"
+    "orchestra/testbench": "3.2.*"
   },
   "suggest": {
     "illuminate/http": "5.0.*|5.1.*|5.2.*",


### PR DESCRIPTION
By upgrading `Orchestra/TestBench` to  3.2, we are using the Laravel 5.2 compatible version.

For more information, see [TestBench's Version Compatibility](https://github.com/orchestral/testbench#version-compatibility).
