### PR TITLE
Fix issue with objects used as array indices

### DIFF
--- a/src/Maatwebsite/Excel/Parsers/ExcelParser.php
+++ b/src/Maatwebsite/Excel/Parsers/ExcelParser.php
@@ -446,7 +446,7 @@ class ExcelParser {
                 if ( $this->cellNeedsParsing($index) )
                 {
                     // Set the value
-                    $parsedCells[$index] = $this->parseCell($index);
+                    $parsedCells[(string) $index] = $this->parseCell($index);
                 }
 
                 $i++;


### PR DESCRIPTION
Fixes an issue where objects (such as PHPExcel_RichText) are used as array indices, causing illegal offset type errors.
