### PR TITLE
Fix heading generation when default overridden in settings.

### DIFF
--- a/src/Maatwebsite/Excel/Classes/LaravelExcelWorksheet.php
+++ b/src/Maatwebsite/Excel/Classes/LaravelExcelWorksheet.php
@@ -110,6 +110,9 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
     {
         parent::__construct($pParent, $pTitle);
         $this->setParent($pParent);
+        // check if we should generate headings
+        // defaults to true if not overridden by settings
+        $this->autoGenerateHeading = Config::get('excel.export.generate_heading_by_indices', true);
     }
 
     /**
@@ -671,10 +674,7 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
      */
     protected function generateHeadingByIndices()
     {
-        if (!$this->autoGenerateHeading)
-            return false;
-
-        return Config::get('excel.export.generate_heading_by_indices', false);
+        return $this->autoGenerateHeading;
     }
 
     /**


### PR DESCRIPTION
Fixed pull request for #871.

When a default value of `false` was set in the settings file, overriding in the `fromArray()` method was impossible.

Fixed by setting the value in the constructor from the settings file and letting the `setAutoHeadingGeneration()` method do it's job, then having `generateHeadingByIndices()` just return the value of `$autoGenerateHeading`.
