### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+/.github export-ignore
+/tests export-ignore
+/docs export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
Add a .gitattributes file to prevent that composer loads files that are not needed in production.
