### PR TITLE
Correct app alias from 'excel' to 'phpexcel'

### DIFF
--- a/src/Maatwebsite/Excel/ExcelServiceProvider.php
+++ b/src/Maatwebsite/Excel/ExcelServiceProvider.php
@@ -187,7 +187,7 @@ class ExcelServiceProvider extends ServiceProvider {
             return $excel;
         });
         
-        $this->app->alias('excel', Excel::class);
+        $this->app->alias('phpexcel', PHPExcel::class);
     }
 
     /**


### PR DESCRIPTION
Current release 1.2.5 breaks functionality, this is urgent.
