### PR TITLE
Update CellWriter.php

### DIFF
--- a/src/Maatwebsite/Excel/Writers/CellWriter.php
+++ b/src/Maatwebsite/Excel/Writers/CellWriter.php
@@ -119,7 +119,7 @@ class CellWriter {
     public function setFontWeight($bold = true)
     {
         return $this->setStyle('font', array(
-            'bold' => ($bold == 'bold' || $bold) ? true : false
+            'bold' => ($bold === 'bold' || $bold === true)
         ));
     }
 


### PR DESCRIPTION
Passing any string value (e.g. `"normal"`) or indeed any truthy value at all to `CellWriter::setFontWeight()` will result in bold text, so this enforces that it has to be either `"bold"` or `true`. Also, ternary isn't needed.
