### PR TITLE
Preserve active sheet index when calling store()

### DIFF
--- a/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
+++ b/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
@@ -356,14 +356,8 @@ class LaravelExcelWriter {
         // Set the extension
         $this->ext = $ext;
 
-        // Preserve any existing active sheet index
-        $activeIndex = $this->getExcel()->getActiveSheetIndex();
-
         // Render the XLS
         $this->_render();
-
-        // Restore active sheet index.
-        $this->setActiveSheetIndex($activeIndex);
 
         // Set the storage path and file
         $toStore = $this->storagePath . '/' . $this->filename . '.' . $this->ext;
@@ -417,6 +411,9 @@ class LaravelExcelWriter {
      */
     protected function _render()
     {
+        // Preserve any existing active sheet index
+        $activeIndex = $this->getExcel()->getActiveSheetIndex();
+
         //Fix borders for merged cells
         foreach($this->getAllSheets() as $sheet){
 
@@ -427,6 +424,9 @@ class LaravelExcelWriter {
                 $sheet->duplicateStyle($style, $cells);
             }
         }
+
+        // Restore active sheet index.
+        $this->setActiveSheetIndex($activeIndex);
 
         // There should be enough sheets to continue rendering
         if ($this->excel->getSheetCount() < 0)

--- a/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
+++ b/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
@@ -356,8 +356,14 @@ class LaravelExcelWriter {
         // Set the extension
         $this->ext = $ext;
 
+        // Preserve any existing active sheet index
+        $activeIndex = $this->getExcel()->getActiveSheetIndex();
+
         // Render the XLS
         $this->_render();
+
+        // Restore active sheet index.
+        $this->setActiveSheetIndex($activeIndex);
 
         // Set the storage path and file
         $toStore = $this->storagePath . '/' . $this->filename . '.' . $this->ext;


### PR DESCRIPTION
This pull request follows on from the handy #987 

A small fix to preserve the users active sheet index when a call is made to `store()` in the writer.

My use case is as follows (A spreadsheet with 2 sheets):

<pre>
Excel::load('spreadsheet_with_2_sheets.xlsx', function($reader) {
	// makes some modifications to sheet 1
	// ...
})
->setActiveSheetIndex(0)
->store('xlsx');
</pre>

Currently within the `store()` the call to `$this->_render()` will overwrite my index of 0 resulting in the outputted spreadsheet always showing sheet 2 by default when opened in Excel.