### PR TITLE
Check if any sheets have been added

### DIFF
--- a/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
+++ b/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
@@ -414,6 +414,11 @@ class LaravelExcelWriter {
         // Preserve any existing active sheet index
         $activeIndex = $this->getExcel()->getActiveSheetIndex();
 
+        // getAllSheets() returns $this if no sheets were added to the excel file
+        if ($this->getAllSheets() instanceof $this) {
+            throw new LaravelExcelException('[ERROR] Aborting spreadsheet render: a minimum of 1 sheet is required.');
+        }
+
         //Fix borders for merged cells
         foreach($this->getAllSheets() as $sheet){
 

--- a/tests/Writers/ExcelWriterTest.php
+++ b/tests/Writers/ExcelWriterTest.php
@@ -235,4 +235,13 @@ class ExcelWriterTest extends TestCase {
 
         $this->assertEquals(1234 + 1234, $results[8]['number']);
     }
+
+    /**
+     * @expectedException Maatwebsite\Excel\Exceptions\LaravelExcelException
+     * @expectedExceptionMessage [ERROR] Aborting spreadsheet render: a minimum of 1 sheet is required.
+     */
+    public function testNoSheets()
+    {
+        Excel::create('no_sheets', function ($writer) {})->string();
+    }
 }


### PR DESCRIPTION
- This will prevent the error "Call to a member function getMergeCells() on string"
- $this->getAllSheets() returns an array if sheets were added but it
will return $this if not, causing the foreach to loop through the
properties of $this resulting in calling getMergeCells on a string (the
file name).

It will now give a LaravelExcelException with the message `[ERROR] Aborting spreadsheet render: a minimum of 1 sheet is required.`.

Resolves: 
- https://github.com/Maatwebsite/Laravel-Excel/issues/1077
- https://github.com/Maatwebsite/Laravel-Excel/issues/924
- https://github.com/Maatwebsite/Laravel-Excel/issues/898
- https://github.com/Maatwebsite/Laravel-Excel/issues/880