### PR TITLE
Add setTextRotation to the CellWriter of v1.3

### DIFF
--- a/src/Maatwebsite/Excel/Writers/CellWriter.php
+++ b/src/Maatwebsite/Excel/Writers/CellWriter.php
@@ -153,6 +153,17 @@ class CellWriter {
     }
 
     /**
+     * Set the text rotation
+     * @param integer $alignment
+     * @return  CellWriter
+     */
+    public function setTextRotation($degrees)
+    {
+      $style = $this->getCellStyle()->getAlignment()->setTextRotation($degrees);
+      return $this;
+    }
+
+    /**
      * Set the alignment
      * @param string $alignment
      * @return  CellWriter


### PR DESCRIPTION
Hi, I was looking for the setTextOrientation method on v1.3 as I'm working on a project on Laravel 4.2, and found that the method on v2.x does work with v1.3 as well so I was wondering if you could add it to v1.3 ? Thanks