### PR TITLE
Enabling chunk file without header

### DIFF
--- a/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
+++ b/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
@@ -669,8 +669,8 @@ class LaravelExcelReader
         for ($startRow = 0; $startRow < $totalRows; $startRow += $chunkSize) {
 
             // Set start index
-            $startIndex = ($startRow == 0) ? $startRow : $startRow - 1;
-            $chunkSize  = ($startRow == 0) ? $size + 1 : $size;
+            $startIndex = ($startRow == 0 || !$this->hasHeading()) ? $startRow : $startRow - 1;
+            $chunkSize  = ($startRow == 0 && $this->hasHeading()) ? $size + 1 : $size;
 
             $job = new ChunkedReadJob(
                 $this->file,


### PR DESCRIPTION
The current code if you chunk a file and this file doesn't have header, retrieves on the second iteration the last row again, duplicating information.

If we get an array in iterations of 10 items, on the first iteration we get 11 elements, 0 to 10 array. On second iteration we receive again element 10 of the last array.

Was loading this data on a database with unique constraints, using this call, to retrieve the data as chunk:
`Excel::filter('chunk')->noHeading()->setSeparator("\n")->setDelimiter("\t")->setEnclosure("")->load($file)->chunk(1000, function($reader) {}`

This change fixed the problem importing the data.