### PR TITLE
Remove take from first()

### DIFF
--- a/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
+++ b/src/Maatwebsite/Excel/Readers/LaravelExcelReader.php
@@ -625,7 +625,7 @@ class LaravelExcelReader
      */
     public function first($columns = [])
     {
-        return $this->take(1)->get($columns)->first();
+        return $this->get($columns)->first();
     }
 
     /**


### PR DESCRIPTION
This is probably done for optimizing the reading, but when you call `first()` to get the first sheet, it sets the take on the reader, which causes the reader to only get the first row of the sheet.
You can test this by setting `force_sheets_collection` to `true` and then parse a file with multiple rows:

```
\Excel::load($file, function($reader) {
    $sheet = $reader->get()[0]->toArray();
    dump($sheet);
    $sheet = $reader->first()->toArray();
    dump($sheet);
})->get();
```

The first will contain all rows, the second one just 1.