### PR TITLE
Add heading getter/setter to RowCollection

### DIFF
--- a/src/Maatwebsite/Excel/Collections/RowCollection.php
+++ b/src/Maatwebsite/Excel/Collections/RowCollection.php
@@ -13,4 +13,27 @@
  */
 class RowCollection extends ExcelCollection {
 
+    /**
+     * Sheet heading
+     * @var array
+     */
+    protected $heading;
+
+    /**
+     * Get the heading
+     * @return array
+     */
+    public function getHeading()
+    {
+        return $this->heading;
+    }
+
+    /**
+     * Set the heading
+     * @param array $heading
+     */
+    public function setHeading(array $heading)
+    {
+        $this->heading = $heading;
+    }
 }

--- a/src/Maatwebsite/Excel/Parsers/ExcelParser.php
+++ b/src/Maatwebsite/Excel/Parsers/ExcelParser.php
@@ -355,6 +355,9 @@ class ExcelParser {
         // set sheet title
         $parsedRows->setTitle($this->excel->getActiveSheet()->getTitle());
 
+        // set sheet heading
+        $parsedRows->setHeading($this->indices);
+
         // Get the start row
         $startRow = $this->getStartRow();
 


### PR DESCRIPTION
Makes it easier to get the headings; can now do `$sheet->getHeading()` instead of `$sheet->first()->keys()->toArray()`.

Not sure if `heading` is the best name, but that seems to be used in the config etc.