### PR TITLE
Change recommended mpdf version to 6.1

### DIFF
--- a/docs/export/export.md
+++ b/docs/export/export.md
@@ -29,6 +29,6 @@ To download the created file, use `->export($ext)` or `->download($ext)`.
 
 #### Export to PDF
 
-To export files to pdf, you will have to include `"dompdf/dompdf": "~0.6.1"`, `"mpdf/mpdf": "~5.7.3"` or `"tecnick.com/tcpdf": "~6.0.0"` in your `composer.json` and change the `export.pdf.driver` config setting accordingly.
+To export files to pdf, you will have to include `"dompdf/dompdf": "~0.6.1"`, `"mpdf/mpdf": "~6.1"` or `"tecnick.com/tcpdf": "~6.0.0"` in your `composer.json` and change the `export.pdf.driver` config setting accordingly.
 
     ->export('pdf');


### PR DESCRIPTION
"mpdf/mpdf": "~5.7.3" version gives PHP 7 Deprecated constructor error.
I recommend to upgrade it to "mpdf/mpdf": "~6.1" version.