### PR TITLE
Catch invalid date value ErrorException and return NULL

### DIFF
--- a/src/Maatwebsite/Excel/Parsers/ExcelParser.php
+++ b/src/Maatwebsite/Excel/Parsers/ExcelParser.php
@@ -576,8 +576,15 @@ class ExcelParser {
         // If has a date
         if ( $cellContent = $this->cell->getCalculatedValue() )
         {
-            // Convert excel time to php date object
-            $date = PHPExcel_Shared_Date::ExcelToPHPObject($this->cell->getCalculatedValue())->format('Y-m-d H:i:s');
+            try
+            {
+                // Convert excel time to php date object
+                $date = PHPExcel_Shared_Date::ExcelToPHPObject($this->cell->getCalculatedValue())->format('Y-m-d H:i:s');
+            }
+            catch( \ErrorException $ex )
+            {
+                return null ;
+            }
 
             // Parse with carbon
             $date = Carbon::parse($date);


### PR DESCRIPTION
When a cell Date in not valid PHPExcel_Shared_Date::ExcelToPHPObject() throw a ErrorException in PHPExcel_Shared_Date::ExcelToPHP().
An ErrorException make the program die.

So add a catch in parseDateAsCarbon() to return a NULL value, like the program could continue and decide what to do with a NULL value.

Cheers, Cyrille.