### PR TITLE
Fix to prevent blank spreadsheets

### DIFF
--- a/src/Maatwebsite/Excel/Classes/LaravelExcelWorksheet.php
+++ b/src/Maatwebsite/Excel/Classes/LaravelExcelWorksheet.php
@@ -601,8 +601,8 @@ class LaravelExcelWorksheet extends PHPExcel_Worksheet {
                 foreach ($array as $key1 => &$row)
                 {
                     $data[$key1] = [];
-                    array_walk($row, function($cell, $key2) use ($key1) {
-                        $data[$key1][$key2] = !is_array($cell) ?: $cell;
+                    array_walk($row, function($cell, $key2) use ($key1, &$data) {
+                        $data[$key1][$key2] = is_array($cell) ? '': $cell;
                     });
                 }
             }


### PR DESCRIPTION
$data is not being passed as a reference into the array walk. So it will always return as array(0 => array()) which is causing blank sheets in the export fromArray() function. 
Also !is_array was also causing a blank array and '' was replaced instead of true

This has been tested on Laravel 5.4 branch and PHP 7.1
