### PR TITLE
Adding ext-zip to requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
   ],
   "require": {
     "php": ">=5.5",
+    "ext-zip": "*",
     "phpoffice/phpexcel": "1.8.*",
     "illuminate/cache": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
     "illuminate/config": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",


### PR DESCRIPTION
Hello,

i'm adding ext-zip to requirements because tests are failing without this extension.

thanks.

edit : the php 7.0 and php 7.1 tests are failed again, and i don't know why, they pass on my machine, it's strange