### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require-dev": {
     "phpseclib/phpseclib": "~1.0",
     "phpunit/phpunit": "~4.0",
-    "mockery/mockery": "~0.9",
+    "mockery/mockery": "~1.0",
     "orchestra/testbench": "3.1.*|3.2.*|3.3.*|3.4.*|3.5.*"
   },
   "suggest": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`~1.0`](https://github.com/mockery/mockery/releases/tag/1.0).