### PR TITLE
Issue when version of laravel are less than 5.2

### DIFF
--- a/src/Maatwebsite/Excel/ExcelServiceProvider.php
+++ b/src/Maatwebsite/Excel/ExcelServiceProvider.php
@@ -57,16 +57,23 @@ class ExcelServiceProvider extends ServiceProvider {
 
         //Set the autosizing settings
         $this->setAutoSizingSettings();
-        
+		
+		//Enable an "export" method on Eloquent collections. ie: model::all()->export('file');
+        global $app;
+        $version = explode(".", $app::VERSION);
         //Enable an "export" method on Eloquent collections. ie: model::all()->export('file');
-        Collection::macro('export', function($filename, $type = 'xlsx', $method = 'download') {
-	        $model = $this;
-	        Facades\Excel::create($filename, function($excel) use ($model, $filename) {
-		        $excel->sheet($filename, function($sheet) use ($model) {
-			        $sheet->fromModel($model);
-		        });
-	        })->$method($type);
-        });
+        if(intval($version[0])>=5){
+            if(intval($version[0])==5 && intval($version[1])>=2){
+                Collection::macro('export', function($filename, $type = 'xlsx', $method = 'download') {
+                    $model = $this;
+                    Facades\Excel::create($filename, function($excel) use ($model, $filename) {
+                        $excel->sheet($filename, function($sheet) use ($model) {
+                            $sheet->fromModel($model);
+                        });
+                    })->$method($type);
+                });
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This check the version of laravel and if are 5.2 or more, enable the "export" method on Eloquent collections