### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Collections/CellCollectionTest.php
+++ b/tests/Collections/CellCollectionTest.php
@@ -55,8 +55,8 @@ class CellCollectionTest extends TestCase {
 
     public function testEmpty()
     {
-        $this->assertFalse(empty($this->collection->two));
-        $this->assertTrue(empty($this->collection->nonexisting));
+        $this->assertNotEmpty($this->collection->two);
+        $this->assertEmpty($this->collection->nonexisting);
     }
 
 

--- a/tests/Excel/ExcelTestCase.php
+++ b/tests/Excel/ExcelTestCase.php
@@ -36,7 +36,7 @@ class ExcelTestCase extends PHPUnit_Framework_TestCase {
      */
     public function testConstructor()
     {
-        $this->assertInstanceOf('Maatwebsite\Excel\Excel', $this->excel);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Excel::class, $this->excel);
     }
 
     /**

--- a/tests/Files/CsvExcelFileTest.php
+++ b/tests/Files/CsvExcelFileTest.php
@@ -8,7 +8,7 @@ class CsvExcelFileTest extends TestCase {
     public function testInit()
     {
         $importer = app('CsvTestImport');
-        $this->assertInstanceOf('Maatwebsite\Excel\Files\ExcelFile', $importer);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Files\ExcelFile::class, $importer);
     }
 
 
@@ -17,7 +17,7 @@ class CsvExcelFileTest extends TestCase {
         $importer = app('TestImport');
         $results = $importer->get();
 
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $results);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $results);
         $this->assertCount(5, $results);
     }
 

--- a/tests/Files/ExcelFileTest.php
+++ b/tests/Files/ExcelFileTest.php
@@ -11,7 +11,7 @@ class ExcelFileTest extends TestCase {
     public function testInit()
     {
         $importer = app('TestImport');
-        $this->assertInstanceOf('Maatwebsite\Excel\Files\ExcelFile', $importer);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Files\ExcelFile::class, $importer);
     }
 
 
@@ -38,7 +38,7 @@ class ExcelFileTest extends TestCase {
     {
         $importer = app('TestImport');
         $importer->loadFile();
-        $this->assertInstanceOf('Maatwebsite\Excel\Readers\LaravelExcelReader', $importer->getFileInstance());
+        $this->assertInstanceOf(\Maatwebsite\Excel\Readers\LaravelExcelReader::class, $importer->getFileInstance());
     }
 
 
@@ -47,7 +47,7 @@ class ExcelFileTest extends TestCase {
         $importer = app('TestImport');
         $results = $importer->get();
 
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $results);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $results);
         $this->assertCount(5, $results);
     }
 
@@ -57,13 +57,13 @@ class ExcelFileTest extends TestCase {
         $importer = app('TestImport');
         $results = $importer->handleImport();
 
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $results);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $results);
         $this->assertCount(5, $results);
 
         $importer = app('TestFile');
         $results = $importer->handleImport();
 
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $results);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $results);
         $this->assertCount(5, $results);
     }
 

--- a/tests/Files/NewExcelFileTest.php
+++ b/tests/Files/NewExcelFileTest.php
@@ -11,7 +11,7 @@ class NewExcelFileTest extends TestCase {
     public function testInit()
     {
         $exporter = app('TestExport');
-        $this->assertInstanceOf('Maatwebsite\Excel\Files\NewExcelFile', $exporter);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Files\NewExcelFile::class, $exporter);
     }
 
 
@@ -26,7 +26,7 @@ class NewExcelFileTest extends TestCase {
     {
         $exporter = app('TestExport');
         $exporter->createNewFile();
-        $this->assertInstanceOf('Maatwebsite\Excel\Writers\LaravelExcelWriter', $exporter->getFileInstance());
+        $this->assertInstanceOf(\Maatwebsite\Excel\Writers\LaravelExcelWriter::class, $exporter->getFileInstance());
     }
 
 

--- a/tests/Readers/ChineseXlsReaderTest.php
+++ b/tests/Readers/ChineseXlsReaderTest.php
@@ -46,7 +46,7 @@ class ChineseXlsReaderTest extends TestCase {
     public function testloadChineseXls()
     {
         $this->assertEquals($this->reader, $this->loadedXls);
-        $this->assertInstanceOf('PHPExcel', $this->reader->getExcel());
+        $this->assertInstanceOf(\PHPExcel::class, $this->reader->getExcel());
     }
 
     /**
@@ -56,7 +56,7 @@ class ChineseXlsReaderTest extends TestCase {
     public function testGet()
     {
         $got = $this->loadedXls->get();
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $got);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $got);
         $this->assertCount(2, $got);
     }
 

--- a/tests/Readers/CustomValueBinderTest.php
+++ b/tests/Readers/CustomValueBinderTest.php
@@ -37,7 +37,7 @@ class CustomValuBinderTest extends TestCase {
     public function testDefaultGet()
     {
         $got = $this->loadedFile->get();
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $got);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $got);
         $this->assertCount(5, $got);
     }
 
@@ -45,7 +45,7 @@ class CustomValuBinderTest extends TestCase {
     {
         $got = $this->loadedFile->toArray();
 
-        $this->assertTrue(is_string($got[0][0]));
+        $this->assertInternalType('string', $got[0][0]);
         $this->assertEquals('00123', $got[0][0]);
     }
 
@@ -53,7 +53,7 @@ class CustomValuBinderTest extends TestCase {
     {
         $got = $this->loadedFile->toArray();
 
-        $this->assertTrue(is_null($got[1][0]));
+        $this->assertNull($got[1][0]);
         $this->assertEquals('', $got[1][0]);
     }
 
@@ -61,7 +61,7 @@ class CustomValuBinderTest extends TestCase {
     {
         $got = $this->loadedFile->toArray();
 
-        $this->assertTrue(is_string($got[2][0]));
+        $this->assertInternalType('string', $got[2][0]);
         $this->assertEquals('null', $got[2][0]);
     }
 
@@ -69,7 +69,7 @@ class CustomValuBinderTest extends TestCase {
     {
         $got = $this->loadedFile->toArray();
 
-        $this->assertTrue(is_string($got[3][0]));
+        $this->assertInternalType('string', $got[3][0]);
         $this->assertEquals('=1+2', $got[3][0]);
     }
 
@@ -77,7 +77,7 @@ class CustomValuBinderTest extends TestCase {
     {
         $got = $this->loadedFile->toArray();
 
-        $this->assertTrue(is_string($got[4][0]));
+        $this->assertInternalType('string', $got[4][0]);
         $this->assertEquals('true', $got[4][0]);
     }
 

--- a/tests/Readers/MultipleSheetsXlsReaderTest.php
+++ b/tests/Readers/MultipleSheetsXlsReaderTest.php
@@ -26,7 +26,7 @@ class MultipleSheetsXlsReaderTest extends TestCase {
     public function testGet()
     {
         $got = $this->loadedFile->get();
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\SheetCollection', $got);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\SheetCollection::class, $got);
         $this->assertCount(2, $got);
     }
 
@@ -56,7 +56,7 @@ class MultipleSheetsXlsReaderTest extends TestCase {
         $sheet = $this->loadedFile->get();
 
         $this->assertEquals('Sheet2', $sheet->getTitle());
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $sheet);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $sheet);
         $this->assertCount(5, $sheet);
     }
 
@@ -68,7 +68,7 @@ class MultipleSheetsXlsReaderTest extends TestCase {
         $sheet = $this->loadedFile->get();
 
         $this->assertEquals('Sheet2', $sheet->getTitle());
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $sheet);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $sheet);
         $this->assertCount(5, $sheet);
     }
 
@@ -78,7 +78,7 @@ class MultipleSheetsXlsReaderTest extends TestCase {
         $this->reload();
 
         $got = $this->loadedFile->get();
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\SheetCollection', $got);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\SheetCollection::class, $got);
         $this->assertCount(2, $got);
 
         // get first sheet
@@ -86,7 +86,7 @@ class MultipleSheetsXlsReaderTest extends TestCase {
 
         // assert sheet title
         $this->assertEquals('Sheet1', $sheet->getTitle());
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $sheet);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $sheet);
         $this->assertCount(5, $sheet);
     }
 
@@ -96,7 +96,7 @@ class MultipleSheetsXlsReaderTest extends TestCase {
         $this->reload();
 
         $got = $this->loadedFile->get();
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\SheetCollection', $got);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\SheetCollection::class, $got);
         $this->assertCount(2, $got);
 
         // get first sheet
@@ -104,7 +104,7 @@ class MultipleSheetsXlsReaderTest extends TestCase {
 
         // assert sheet title
         $this->assertEquals('Sheet1', $sheet->getTitle());
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $sheet);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $sheet);
         $this->assertCount(5, $sheet);
     }
 

--- a/tests/Readers/ZerosHandlingReaderTest.php
+++ b/tests/Readers/ZerosHandlingReaderTest.php
@@ -27,7 +27,7 @@ class ZerosHandlingReaderTest extends TestCase {
     public function testDefaultGet()
     {
         $got = $this->loadedFile->get();
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $got);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $got);
         $this->assertCount(6, $got);
     }
 

--- a/tests/Readers/traits/ImportTrait.php
+++ b/tests/Readers/traits/ImportTrait.php
@@ -46,7 +46,7 @@ trait ImportTrait {
     public function testLoadFile()
     {
         $this->assertEquals($this->reader, $this->loadedFile);
-        $this->assertInstanceOf('PHPExcel', $this->reader->getExcel());
+        $this->assertInstanceOf(\PHPExcel::class, $this->reader->getExcel());
     }
 
     /**

--- a/tests/Readers/traits/SingleImportTestingTrait.php
+++ b/tests/Readers/traits/SingleImportTestingTrait.php
@@ -6,7 +6,7 @@ trait SingleImportTestingTrait {
     public function testGet()
     {
         $got = $this->loadedFile->get();
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $got);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $got);
         $this->assertCount(5, $got);
     }
 
@@ -16,7 +16,7 @@ trait SingleImportTestingTrait {
         $columns = ['heading_one', 'heading_two'];
         $got = $this->loadedFile->get($columns);
 
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $got);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $got);
         $this->assertCount(5, $got);
     }
 
@@ -24,7 +24,7 @@ trait SingleImportTestingTrait {
     public function testAll()
     {
         $all = $this->loadedFile->all();
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\RowCollection', $all);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\RowCollection::class, $all);
         $this->assertCount(5, $all);
     }
 
@@ -32,7 +32,7 @@ trait SingleImportTestingTrait {
     public function testFirst()
     {
         $first = $this->loadedFile->first();
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\CellCollection', $first);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\CellCollection::class, $first);
 
         // 3 columns
         $this->assertCount(3, $first);
@@ -44,7 +44,7 @@ trait SingleImportTestingTrait {
         $columns = ['heading_one', 'heading_two'];
         $first = $this->loadedFile->first($columns);
 
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\CellCollection', $first);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\CellCollection::class, $first);
         $this->assertCount(count($columns), $first);
     }
 
@@ -55,7 +55,7 @@ trait SingleImportTestingTrait {
 
         $this->loadedFile->each(function($cells) use($me) {
 
-            $me->assertInstanceOf('Maatwebsite\Excel\Collections\CellCollection', $cells);
+            $me->assertInstanceOf(\Maatwebsite\Excel\Collections\CellCollection::class, $cells);
 
         });
     }
@@ -173,7 +173,7 @@ trait SingleImportTestingTrait {
     public function testByConfig()
     {
         $config = $this->loadedFile->byConfig('excel.import.sheets');
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\SheetCollection', $config);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\SheetCollection::class, $config);
     }
 
 
@@ -183,10 +183,10 @@ trait SingleImportTestingTrait {
 
         $config = $this->loadedFile->byConfig('excel.import.sheets', function($config) use($me)
         {
-            $me->assertInstanceOf('Maatwebsite\Excel\Readers\ConfigReader', $config);
+            $me->assertInstanceOf(\Maatwebsite\Excel\Readers\ConfigReader::class, $config);
         });
 
-        $this->assertInstanceOf('Maatwebsite\Excel\Collections\SheetCollection', $config);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Collections\SheetCollection::class, $config);
     }
 
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ class TestCase extends TestBenchTestCase
     public function testExcelClass()
     {
         $excel = App::make('Maatwebsite\Excel\Excel');
-        $this->assertInstanceOf('Maatwebsite\Excel\Excel', $excel);
+        $this->assertInstanceOf(\Maatwebsite\Excel\Excel::class, $excel);
     }
 
 

--- a/tests/Writers/ExcelWriterTest.php
+++ b/tests/Writers/ExcelWriterTest.php
@@ -185,7 +185,7 @@ class ExcelWriterTest extends TestCase {
             });
         })->store('csv', __DIR__ . '/exports', true);
 
-        $this->assertTrue(file_exists($info['full']));
+        $this->assertFileExists($info['full']);
     }
 
     public function testCreateSheetFromArray()
@@ -198,7 +198,7 @@ class ExcelWriterTest extends TestCase {
             });
         })->store('csv', __DIR__ . '/exports', true);
 
-        $this->assertTrue(file_exists($info['full']));
+        $this->assertFileExists($info['full']);
     }
 
     public function testCreateSheetFromArrayThrowsException()
@@ -231,7 +231,7 @@ class ExcelWriterTest extends TestCase {
             });
         })->store('xls', __DIR__ . '/exports', true);
 
-        $this->assertTrue(file_exists($info['full']));
+        $this->assertFileExists($info['full']);
 
         $results = Excel::load($info['full'], null, false, true)->calculate()->toArray();
 
@@ -240,16 +240,16 @@ class ExcelWriterTest extends TestCase {
         $this->assertEquals('01234HelloWorld', $results[2]['number']);
         $this->assertEquals('12345678901234567890', $results[3]['number']);
 
-        $this->assertTrue(is_double($results[4]['number']));
+        $this->assertInternalType('double', $results[4]['number']);
         $this->assertEquals((double) 1234, $results[4]['number']);
 
-        $this->assertTrue(is_double($results[5]['number']));
+        $this->assertInternalType('double', $results[5]['number']);
         $this->assertEquals('1234.02', $results[5]['number']);
 
-        $this->assertTrue(is_double($results[6]['number']));
+        $this->assertInternalType('double', $results[6]['number']);
         $this->assertEquals('0.0231231234423', $results[6]['number']);
 
-        $this->assertTrue(is_double($results[7]['number']));
+        $this->assertInternalType('double', $results[7]['number']);
         $this->assertEquals(4195.99253472222, $results[7]['number']);
 
         $this->assertEquals(1234 + 1234, $results[8]['number']);
@@ -321,6 +321,6 @@ class ExcelWriterTest extends TestCase {
             });
         })->store('csv', __DIR__ . '/exports', true);
 
-        $this->assertTrue(file_exists($info['full']));
+        $this->assertFileExists($info['full']);
     }
 }


### PR DESCRIPTION
I've refactored some tests, using:
- `assertEmpty` and `assertNotEmpty` instead of `empty` function;
- `assertInternalType` instead of `is_*` functions;
- `assertNull` instead of `is_null` function;
- `assertFileExists` instead of `file_exists` function;
- `::class` pseudo-contants in `assertInstanceOf`.