### PR TITLE
bugfix/ioc-container-bindings

### DIFF
--- a/src/Maatwebsite/Excel/ExcelServiceProvider.php
+++ b/src/Maatwebsite/Excel/ExcelServiceProvider.php
@@ -203,6 +203,8 @@ class ExcelServiceProvider extends ServiceProvider {
 
             return $excel;
         });
+
+        $this->app->alias('excel', Excel::class);
     }
 
     /**

--- a/src/Maatwebsite/Excel/ExcelServiceProvider.php
+++ b/src/Maatwebsite/Excel/ExcelServiceProvider.php
@@ -108,6 +108,8 @@ class ExcelServiceProvider extends ServiceProvider {
             $excel->setDefaultProperties();
             return $excel;
         });
+
+        $this->app->alias('phpexcel', PHPExcel::class);
     }
 
     /**
@@ -201,8 +203,6 @@ class ExcelServiceProvider extends ServiceProvider {
 
             return $excel;
         });
-        
-        $this->app->alias('phpexcel', PHPExcel::class);
     }
 
     /**


### PR DESCRIPTION
This PR allows package users to take advantage of Laravel's automatic dependency injection for the package's main class - `Maatwebsite\Excel\Excel` - thus avoiding usage of the facade or having to create an additional service provider to bind the alias.

In addition to that, it moves the `phpexcel` aliasing call to the more appropriate method (which registers that binding in the first place).