### PR TITLE
Using namespace to identify class inside facade

### DIFF
--- a/src/Maatwebsite/Excel/Facades/Excel.php
+++ b/src/Maatwebsite/Excel/Facades/Excel.php
@@ -21,6 +21,6 @@ class Excel extends Facade {
      */
     protected static function getFacadeAccessor()
     {
-        return 'excel';
+        return \Maatwebsite\Excel\Excel::class;
     }
 }


### PR DESCRIPTION
Class cannot be found when on Windows. Using the namespace resolves this problem.
Without this the facade does not resolve and the package is unusable.
Reference: https://github.com/Maatwebsite/Laravel-Excel/issues/1373