### PR TITLE
Added ability to fake excel

### DIFF
--- a/src/Excel.php
+++ b/src/Excel.php
@@ -148,4 +148,24 @@ class Excel
 
         return config('excel.extension_detector.' . strtolower($pathinfo['extension'] ?? ''));
     }
+
+    /**
+     * Get the writer.
+     *
+     * @return Writer
+     */
+    public function getWritter()
+    {
+        return $this->writer;
+    }
+
+    /**
+     * Get the queued writer.
+     *
+     * @return QueuedWriter
+     */
+    public function getQueuedWritter()
+    {
+        return $this->queuedWriter;
+    }
 }

--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -3,13 +3,11 @@
 namespace Maatwebsite\Excel\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Maatwebsite\Excel\Fakes\ExcelFake;
+use Maatwebsite\Excel\Fakes\WriterFake;
+use Maatwebsite\Excel\Fakes\QueuedWriterFake;
+use Illuminate\Contracts\Routing\ResponseFactory;
 
-/**
- * @method static BinaryFileResponse download(object $export, string $fileName, string $writerType = null)
- * @method static bool store(object $export, string $filePath, string $disk = null, string $writerType = null)
- * @method static bool queue(object $export, string $filePath, string $disk = null, string $writerType = null)
- */
 class Excel extends Facade
 {
     /**
@@ -20,5 +18,20 @@ class Excel extends Facade
     protected static function getFacadeAccessor()
     {
         return 'excel';
+    }
+
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @return void
+     */
+    public static function fake()
+    {
+        static::swap(new ExcelFake(
+            app()->make(WriterFake::class),
+            app()->make(QueuedWriterFake::class),
+            app()->make(ResponseFactory::class),
+            app()->make('filesystem')
+        ));
     }
 }

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Maatwebsite\Excel\Fakes;
+
+use Maatwebsite\Excel\Excel;
+
+class ExcelFake extends Excel
+{
+
+}

--- a/src/Fakes/QueuedWriterFake.php
+++ b/src/Fakes/QueuedWriterFake.php
@@ -1,0 +1,8 @@
+<?php namespace Maatwebsite\Excel\Fakes;
+
+use Maatwebsite\Excel\QueuedWriter;
+
+class QueuedWriterFake extends QueuedWriter
+{
+
+}

--- a/src/Fakes/WriterFake.php
+++ b/src/Fakes/WriterFake.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Maatwebsite\Excel\Fakes;
+
+use Maatwebsite\Excel\Writer;
+
+class WriterFake extends Writer
+{
+
+}

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -5,11 +5,14 @@ namespace Maatwebsite\Excel\Tests;
 use Maatwebsite\Excel\Excel;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\View\View;
+use Maatwebsite\Excel\Fakes\ExcelFake;
+use Maatwebsite\Excel\Fakes\WriterFake;
 use Maatwebsite\Excel\Concerns\FromView;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\BeforeWriting;
+use Maatwebsite\Excel\Fakes\QueuedWriterFake;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Facades\Excel as ExcelFacade;
 use Maatwebsite\Excel\Tests\Data\Stubs\EmptyExport;
@@ -41,6 +44,20 @@ class ExcelTest extends TestCase
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertEquals('attachment; filename="filename.xlsx"', $response->headers->get('Content-Disposition'));
+    }
+
+    /**
+     * @test
+     */
+    public function can_fake_an_export_object()
+    {
+        ExcelFacade::fake();
+
+        $excel = $this->app->make(Excel::class);
+
+        $this->assertInstanceOf(ExcelFake::class, $excel);
+        $this->assertInstanceOf(WriterFake::class, $excel->getWritter());
+        $this->assertInstanceOf(QueuedWriterFake::class, $excel->getQueuedWritter());
     }
 
     /**


### PR DESCRIPTION
Assuming you are familiar with Laravel’s testing fakes, this addes the abilty for the developer to test against their exports; ie:

/**
 * @test
 */
public function it_can_export_a_file()
{
    Excel::fake();

    $this->get('/export')->assertStatus(200);

    // Excel::someAssertion();
}

There are no assertions yet only because 3.0 is alpha and to early to now how its api will look.