### PR TITLE
[WIP] Fix Multiple Sheet Exports With Views

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -133,8 +133,10 @@ class Sheet
 
         /** @var Html $reader */
         $reader = IOFactory::createReader('Html');
-        $reader->setSheetIndex($spreadsheet->getActiveSheetIndex());
+        // dump($spreadsheet->getActiveSheetIndex()); // Implementation bug: always return 0
+        $reader->setSheetIndex($spreadsheet->getSheetCount() - 1); // Insert content into the last sheet
         $reader->loadIntoExisting($tempFile, $spreadsheet);
+        $reader->setSheetIndex(0); // return to the first sheet as active
     }
 
     /**

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -133,10 +133,9 @@ class Sheet
 
         /** @var Html $reader */
         $reader = IOFactory::createReader('Html');
-        // dump($spreadsheet->getActiveSheetIndex()); // Implementation bug: always return 0
-        $reader->setSheetIndex($spreadsheet->getSheetCount() - 1); // Insert content into the last sheet
+        // Insert content into the last sheet
+        $reader->setSheetIndex($spreadsheet->getSheetCount() - 1);
         $reader->loadIntoExisting($tempFile, $spreadsheet);
-        $reader->setSheetIndex(0); // return to the first sheet as active
     }
 
     /**

--- a/tests/Concerns/FromViewTest.php
+++ b/tests/Concerns/FromViewTest.php
@@ -7,7 +7,9 @@ use Illuminate\Contracts\View\View;
 use Maatwebsite\Excel\Tests\TestCase;
 use Maatwebsite\Excel\Concerns\FromView;
 use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use Maatwebsite\Excel\Tests\Data\Stubs\SheetForUsersFromView;
 
 class FromViewTest extends TestCase
 {
@@ -69,6 +71,60 @@ class FromViewTest extends TestCase
             ];
         })->prepend(['Name', 'Email'])->toArray();
 
+        $this->assertEquals($expected, $contents);
+    }
+
+    /**
+     * @test
+     */
+    public function can_export_multiple_sheets_from_view()
+    {
+        /** @var Collection|User[] $users */
+        $users = factory(User::class)->times(300)->make();
+
+        $export = new class($users) implements WithMultipleSheets {
+            use Exportable;
+
+            /**
+             * @var Collection
+             */
+            protected $users;
+
+            /**
+             * @param Collection $users
+             */
+            public function __construct(Collection $users)
+            {
+                $this->users = $users;
+            }
+
+            /**
+             * @return SheetForUsersFromView[]
+             */
+            public function sheets() : array
+            {
+                return [
+                    new SheetForUsersFromView($this->users->forPage(1, 100)),
+                    new SheetForUsersFromView($this->users->forPage(2, 100)),
+                    new SheetForUsersFromView($this->users->forPage(3, 100)),
+                ];
+            }
+        };
+
+        $response = $export->store('from-view.xlsx');
+
+        $this->assertTrue($response);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 0);
+
+        $expected = $users->forPage(3, 100)->map(function (User $user) {
+            return [
+                $user->name,
+                $user->email,
+            ];
+        })->prepend(['Name', 'Email'])->toArray();
+
+        $this->assertEquals(101, sizeof($contents));
         $this->assertEquals($expected, $contents);
     }
 }

--- a/tests/Concerns/FromViewTest.php
+++ b/tests/Concerns/FromViewTest.php
@@ -117,6 +117,18 @@ class FromViewTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 0);
 
+        $expected = $users->forPage(1, 100)->map(function (User $user) {
+            return [
+                $user->name,
+                $user->email,
+            ];
+        })->prepend(['Name', 'Email'])->toArray();
+
+        $this->assertEquals(101, sizeof($contents));
+        $this->assertEquals($expected, $contents);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 2);
+
         $expected = $users->forPage(3, 100)->map(function (User $user) {
             return [
                 $user->name,

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Tests\TestCase;
+use Maatwebsite\Excel\Tests\Data\Stubs\SheetWith100Rows;
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Tests\Data\Stubs\SheetForUsersFromView;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+
+class WithMultipleSheetsTest extends TestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->withFactories(__DIR__ . '/../Data/Stubs/Database/Factories');
+    }
+
+    /**
+     * @test
+     */
+    public function can_export_with_multiple_sheets_using_collections()
+    {
+        $export = new class implements WithMultipleSheets
+        {
+            use Exportable;
+
+            /**
+             * @return SheetWith100Rows[]
+             */
+            public function sheets() : array
+            {
+                return [
+                    new SheetWith100Rows('A'),
+                    new SheetWith100Rows('B'),
+                    new SheetWith100Rows('C'),
+                ];
+            }
+        };
+
+        $export->store('from-view.xlsx');
+
+        $this->assertCount(100, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 0));
+        $this->assertCount(100, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 1));
+        $this->assertCount(100, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 2));
+    }
+
+    /**
+     * @test
+     */
+    public function can_export_multiple_sheets_from_view()
+    {
+        /** @var Collection|User[] $users */
+        $users = factory(User::class)->times(300)->make();
+
+        $export = new class($users) implements WithMultipleSheets {
+            use Exportable;
+
+            /**
+             * @var Collection
+             */
+            protected $users;
+
+            /**
+             * @param Collection $users
+             */
+            public function __construct(Collection $users)
+            {
+                $this->users = $users;
+            }
+
+            /**
+             * @return SheetForUsersFromView[]
+             */
+            public function sheets() : array
+            {
+                return [
+                    new SheetForUsersFromView($this->users->forPage(1, 100)),
+                    new SheetForUsersFromView($this->users->forPage(2, 100)),
+                    new SheetForUsersFromView($this->users->forPage(3, 100)),
+                ];
+            }
+        };
+
+        $export->store('from-view.xlsx');
+
+        $this->assertCount(101, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 0));
+        $this->assertCount(101, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 1));
+        $this->assertCount(101, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 2));
+    }
+}

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -59,7 +59,8 @@ class WithMultipleSheetsTest extends TestCase
         /** @var Collection|User[] $users */
         $users = factory(User::class)->times(300)->make();
 
-        $export = new class($users) implements WithMultipleSheets {
+        $export = new class($users) implements WithMultipleSheets
+        {
             use Exportable;
 
             /**

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -2,13 +2,13 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Maatwebsite\Excel\Tests\TestCase;
-use Maatwebsite\Excel\Tests\Data\Stubs\SheetWith100Rows;
 use Illuminate\Support\Collection;
-use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Tests\TestCase;
 use Maatwebsite\Excel\Concerns\Exportable;
-use Maatwebsite\Excel\Tests\Data\Stubs\SheetForUsersFromView;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use Maatwebsite\Excel\Tests\Data\Stubs\SheetWith100Rows;
+use Maatwebsite\Excel\Tests\Data\Stubs\SheetForUsersFromView;
 
 class WithMultipleSheetsTest extends TestCase
 {

--- a/tests/Data/Stubs/SheetForUsersFromView.php
+++ b/tests/Data/Stubs/SheetForUsersFromView.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Support\Collection;
+use Illuminate\Contracts\View\View;
+use Maatwebsite\Excel\Concerns\FromView;
+use Maatwebsite\Excel\Concerns\Exportable;
+
+class SheetForUsersFromView implements FromView
+{
+    use Exportable;
+
+    /**
+     * @var Collection
+     */
+    protected $users;
+
+    /**
+     * @param Collection $users
+     */
+    public function __construct(Collection $users)
+    {
+        $this->users = $users;
+    }
+
+    /**
+     * @return View
+     */
+    public function view(): View
+    {
+        return view('users', [
+            'users' => $this->users,
+        ]);
+    }
+}


### PR DESCRIPTION
* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

This is a work in progress and feedback is appreciated. My assumption is that `activeSheetIndex` is not being increased when a view is used to compose a sheet. 

### Why Should This Be Added?

Fixes #1584 
