### PR TITLE
Adding withHeadings to DownloadCollection and StoreCollection

### DIFF
--- a/src/Mixins/DownloadCollection.php
+++ b/src/Mixins/DownloadCollection.php
@@ -15,13 +15,13 @@ class DownloadCollection
     public function downloadExcel()
     {
         return function (string $fileName, string $writerType = null, $withHeadings = false) {
-            $export = new class($this) implements FromCollection, WithHeadings {
+            $export = new class($this, $withHeadings) implements FromCollection, WithHeadings {
                 use Exportable;
 
                 /**
                  * @var bool
                  */
-                public $withHeadings = false;
+                private $withHeadings;
 
                 /**
                  * @var Collection
@@ -30,10 +30,13 @@ class DownloadCollection
 
                 /**
                  * @param Collection $collection
+                 * @param $withHeading
                  */
-                public function __construct(Collection $collection)
+                public function __construct(Collection $collection, $withHeading = false)
                 {
                     $this->collection = $collection->toBase();
+
+                    $this->withHeadings = $withHeading;
                 }
 
                 /**
@@ -52,8 +55,6 @@ class DownloadCollection
                     return $this->withHeadings ? $this->collection->collapse()->keys()->all() : [];
                 }
             };
-
-            $export->withHeadings = $withHeadings;
 
             return $export->download($fileName, $writerType);
         };

--- a/src/Mixins/DownloadCollection.php
+++ b/src/Mixins/DownloadCollection.php
@@ -5,6 +5,7 @@ namespace Maatwebsite\Excel\Mixins;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
 
 class DownloadCollection
 {
@@ -13,9 +14,14 @@ class DownloadCollection
      */
     public function downloadExcel()
     {
-        return function (string $fileName, string $writerType = null) {
-            $export = new class($this) implements FromCollection {
+        return function (string $fileName, string $writerType = null, $withHeadings = false) {
+            $export = new class($this)  implements FromCollection, WithHeadings  {
                 use Exportable;
+
+                /**
+                 * @var bool
+                 */
+                public $withHeadings = false;
 
                 /**
                  * @var Collection
@@ -37,7 +43,17 @@ class DownloadCollection
                 {
                     return $this->collection;
                 }
+
+                /**
+                 * @return array
+                 */
+                public function headings(): array
+                {
+                    return $this->withHeadings ? $this->collection->collapse()->keys()->all() : [];
+                }
             };
+
+            $export->withHeadings = $withHeadings;
 
             return $export->download($fileName, $writerType);
         };

--- a/src/Mixins/DownloadCollection.php
+++ b/src/Mixins/DownloadCollection.php
@@ -15,7 +15,7 @@ class DownloadCollection
     public function downloadExcel()
     {
         return function (string $fileName, string $writerType = null, $withHeadings = false) {
-            $export = new class($this)  implements FromCollection, WithHeadings  {
+            $export = new class($this) implements FromCollection, WithHeadings  {
                 use Exportable;
 
                 /**

--- a/src/Mixins/DownloadCollection.php
+++ b/src/Mixins/DownloadCollection.php
@@ -4,8 +4,8 @@ namespace Maatwebsite\Excel\Mixins;
 
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
-use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\FromCollection;
 
 class DownloadCollection
 {
@@ -15,7 +15,7 @@ class DownloadCollection
     public function downloadExcel()
     {
         return function (string $fileName, string $writerType = null, $withHeadings = false) {
-            $export = new class($this) implements FromCollection, WithHeadings  {
+            $export = new class($this) implements FromCollection, WithHeadings {
                 use Exportable;
 
                 /**

--- a/src/Mixins/StoreCollection.php
+++ b/src/Mixins/StoreCollection.php
@@ -4,8 +4,8 @@ namespace Maatwebsite\Excel\Mixins;
 
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
-use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\FromCollection;
 
 class StoreCollection
 {

--- a/src/Mixins/StoreCollection.php
+++ b/src/Mixins/StoreCollection.php
@@ -15,13 +15,13 @@ class StoreCollection
     public function storeExcel()
     {
         return function (string $filePath, string $disk = null, string $writerType = null, $withHeadings = false) {
-            $export = new class($this) implements FromCollection, WithHeadings {
+            $export = new class($this, $withHeadings) implements FromCollection, WithHeadings {
                 use Exportable;
 
                 /**
                  * @var bool
                  */
-                public $withHeadings = false;
+                private $withHeadings;
 
                 /**
                  * @var Collection
@@ -30,10 +30,13 @@ class StoreCollection
 
                 /**
                  * @param Collection $collection
+                 * @param $withHeadings = false
                  */
-                public function __construct(Collection $collection)
+                public function __construct(Collection $collection, $withHeadings = false)
                 {
                     $this->collection = $collection->toBase();
+
+                    $this->withHeadings = $withHeadings;
                 }
 
                 /**
@@ -52,8 +55,6 @@ class StoreCollection
                     return $this->withHeadings ? $this->collection->collapse()->keys()->all() : [];
                 }
             };
-
-            $export->withHeadings = $withHeadings;
 
             return $export->store($filePath, $disk, $writerType);
         };

--- a/src/Mixins/StoreCollection.php
+++ b/src/Mixins/StoreCollection.php
@@ -5,6 +5,7 @@ namespace Maatwebsite\Excel\Mixins;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
 
 class StoreCollection
 {
@@ -13,9 +14,14 @@ class StoreCollection
      */
     public function storeExcel()
     {
-        return function (string $filePath, string $disk = null, string $writerType = null) {
-            $export = new class($this) implements FromCollection {
+        return function (string $filePath, string $disk = null, string $writerType = null, $withHeadings = false) {
+            $export = new class($this) implements FromCollection, WithHeadings {
                 use Exportable;
+
+                /**
+                 * @var bool
+                 */
+                public $withHeadings = false;
 
                 /**
                  * @var Collection
@@ -37,7 +43,17 @@ class StoreCollection
                 {
                     return $this->collection;
                 }
+
+                /**
+                 * @return array
+                 */
+                public function headings(): array
+                {
+                    return $this->withHeadings ? $this->collection->collapse()->keys()->all() : [];
+                }
             };
+
+            $export->withHeadings = $withHeadings;
 
             return $export->store($filePath, $disk, $writerType);
         };

--- a/tests/Mixins/DownloadCollectionTest.php
+++ b/tests/Mixins/DownloadCollectionTest.php
@@ -42,7 +42,7 @@ class DownloadCollectionTest extends TestCase
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
 
-        $this->assertEquals($collection->collapse()->keys()->all(), collect($array)->first());
+        $this->assertEquals(['column_1', 'column_2'], collect($array)->first());
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertEquals(
             'attachment; filename="collection-headers-download.xlsx"',

--- a/tests/Mixins/DownloadCollectionTest.php
+++ b/tests/Mixins/DownloadCollectionTest.php
@@ -2,8 +2,8 @@
 
 namespace Maatwebsite\Excel\Tests\Mixins;
 
-use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Excel;
+use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Tests\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -34,8 +34,8 @@ class DownloadCollectionTest extends TestCase
     public function can_store_a_collection_with_headers_as_excel()
     {
         $collection = new Collection([
-            ['column_1' => 'test','column_2' => 'test'],
-            ['column_1' => 'test','column_2' => 'test'],
+            ['column_1' => 'test', 'column_2' => 'test'],
+            ['column_1' => 'test', 'column_2' => 'test'],
         ]);
 
         $response = $collection->downloadExcel('collection-headers-download.xlsx', Excel::XLSX, true);

--- a/tests/Mixins/DownloadCollectionTest.php
+++ b/tests/Mixins/DownloadCollectionTest.php
@@ -57,7 +57,7 @@ class DownloadCollectionTest extends TestCase
     {
         $collection = new Collection([
             ['column_1' => 'test', 'column_2' => 'test'],
-            ['column_1' => 'test', 'column_2' => 'test'],
+            ['column_1' => 'test2', 'column_2' => 'test2'],
         ]);
 
         $response = $collection->downloadExcel('collection-without-headers-download.xlsx', Excel::XLSX, false);
@@ -65,9 +65,7 @@ class DownloadCollectionTest extends TestCase
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
 
         $firstRow = collect($array)->first();
-        $this->assertNotEquals(['column_1', 'column_2'], $firstRow);
-        $this->assertNotEquals([], $firstRow);
-        $this->assertNotNull($firstRow);
+        $this->assertEquals(['test', 'test'], $firstRow);
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertEquals(

--- a/tests/Mixins/DownloadCollectionTest.php
+++ b/tests/Mixins/DownloadCollectionTest.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel\Tests\Mixins;
 
 use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Excel;
 use Maatwebsite\Excel\Tests\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -23,6 +24,28 @@ class DownloadCollectionTest extends TestCase
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertEquals(
             'attachment; filename="collection-download.xlsx"',
+            $response->headers->get('Content-Disposition')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function can_store_a_collection_with_headers_as_excel()
+    {
+        $collection = new Collection([
+            ['column_1' => 'test','column_2' => 'test'],
+            ['column_1' => 'test','column_2' => 'test'],
+        ]);
+
+        $response = $collection->downloadExcel('collection-headers-download.xlsx', Excel::XLSX, true);
+
+        $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
+
+        $this->assertEquals($collection->collapse()->keys()->all(), collect($array)->first());
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
+        $this->assertEquals(
+            'attachment; filename="collection-headers-download.xlsx"',
             $response->headers->get('Content-Disposition')
         );
     }

--- a/tests/Mixins/DownloadCollectionTest.php
+++ b/tests/Mixins/DownloadCollectionTest.php
@@ -49,4 +49,30 @@ class DownloadCollectionTest extends TestCase
             $response->headers->get('Content-Disposition')
         );
     }
+
+    /**
+     * @test
+     */
+    public function can_store_a_collection_without_headers_as_excel()
+    {
+        $collection = new Collection([
+            ['column_1' => 'test', 'column_2' => 'test'],
+            ['column_1' => 'test', 'column_2' => 'test'],
+        ]);
+
+        $response = $collection->downloadExcel('collection-without-headers-download.xlsx', Excel::XLSX, false);
+
+        $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
+
+        $firstRow = collect($array)->first();
+        $this->assertNotEquals(['column_1', 'column_2'], $firstRow);
+        $this->assertNotEquals([], $firstRow);
+        $this->assertNotNull($firstRow);
+
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
+        $this->assertEquals(
+            'attachment; filename="collection-without-headers-download.xlsx"',
+            $response->headers->get('Content-Disposition')
+        );
+    }
 }

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -85,8 +85,7 @@ class StoreCollectionTest extends TestCase
         $this->assertTrue($response);
         $this->assertFileExists($file);
 
-        if (is_file($file))
-        {
+        if (is_file($file)) {
             $array = $this->readAsArray($file, Excel::XLSX);
 
             $firstRow = collect($array)->first();
@@ -96,7 +95,7 @@ class StoreCollectionTest extends TestCase
 
             $this->assertEquals([
                 ['test', 'test'],
-                ['test', 'test']
+                ['test', 'test'],
             ], collect($array)->values()->all());
         }
     }

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -56,9 +56,17 @@ class StoreCollectionTest extends TestCase
 
         $this->assertTrue($response);
         $this->assertFileExists($file);
-        if (is_file($file)) {
+
+        if (is_file($file))
+        {
             $array = $this->readAsArray($file, Excel::XLSX);
-            $this->assertEquals($collection->collapse()->keys()->all(), collect($array)->first());
+            $this->assertEquals(['column_1', 'column_2'], collect($array)->first());
+
+
+            $this->assertEquals([
+                ['test', 'test'],
+                ['test', 'test']
+            ], collect($array)->except(0)->values()->all());
         }
     }
 }

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -57,16 +57,47 @@ class StoreCollectionTest extends TestCase
         $this->assertTrue($response);
         $this->assertFileExists($file);
 
-        if (is_file($file))
-        {
+        if (is_file($file)) {
             $array = $this->readAsArray($file, Excel::XLSX);
             $this->assertEquals(['column_1', 'column_2'], collect($array)->first());
 
+            $this->assertEquals([
+                ['test', 'test'],
+                ['test', 'test'],
+            ], collect($array)->except(0)->values()->all());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_store_a_collection_without_headings_as_excel()
+    {
+        $collection = new Collection([
+            ['column_1' => 'test', 'column_2' => 'test'],
+            ['column_1' => 'test', 'column_2' => 'test'],
+        ]);
+
+        $response = $collection->storeExcel('collection-without-headers-store.xlsx', null, Excel::XLSX, false);
+
+        $file = __DIR__ . '/../Data/Disks/Local/collection-without-headers-store.xlsx';
+
+        $this->assertTrue($response);
+        $this->assertFileExists($file);
+
+        if (is_file($file))
+        {
+            $array = $this->readAsArray($file, Excel::XLSX);
+
+            $firstRow = collect($array)->first();
+            $this->assertNotEquals(['column_1', 'column_2'], $firstRow);
+            $this->assertNotEquals([], $firstRow);
+            $this->assertNotNull($firstRow);
 
             $this->assertEquals([
                 ['test', 'test'],
                 ['test', 'test']
-            ], collect($array)->except(0)->values()->all());
+            ], collect($array)->values()->all());
         }
     }
 }

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -93,7 +93,7 @@ class StoreCollectionTest extends TestCase
 
             $this->assertEquals([
                 ['test', 'test'],
-                ['test', 'test'],
+                ['test2', 'test2'],
             ], collect($array)->values()->all());
         }
     }

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -75,7 +75,7 @@ class StoreCollectionTest extends TestCase
     {
         $collection = new Collection([
             ['column_1' => 'test', 'column_2' => 'test'],
-            ['column_1' => 'test', 'column_2' => 'test'],
+            ['column_1' => 'test2', 'column_2' => 'test2'],
         ]);
 
         $response = $collection->storeExcel('collection-without-headers-store.xlsx', null, Excel::XLSX, false);
@@ -89,9 +89,7 @@ class StoreCollectionTest extends TestCase
             $array = $this->readAsArray($file, Excel::XLSX);
 
             $firstRow = collect($array)->first();
-            $this->assertNotEquals(['column_1', 'column_2'], $firstRow);
-            $this->assertNotEquals([], $firstRow);
-            $this->assertNotNull($firstRow);
+            $this->assertEquals(['test', 'test'], $firstRow);
 
             $this->assertEquals([
                 ['test', 'test'],

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel\Tests\Mixins;
 
 use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Excel;
 use Maatwebsite\Excel\Tests\TestCase;
 
 class StoreCollectionTest extends TestCase
@@ -37,5 +38,28 @@ class StoreCollectionTest extends TestCase
 
         $this->assertTrue($response);
         $this->assertFileExists(__DIR__ . '/../Data/Disks/Test/collection-store.xlsx');
+    }
+
+    /**
+     * @test
+     */
+    public function can_store_a_collection_with_headings_as_excel()
+    {
+        $collection = new Collection([
+            ['column_1' => 'test','column_2' => 'test'],
+            ['column_1' => 'test','column_2' => 'test'],
+        ]);
+
+        $response = $collection->storeExcel('collection-headers-store.xlsx', null, Excel::XLSX, true);
+
+        $file = __DIR__ . '/../Data/Disks/Local/collection-headers-store.xlsx';
+
+        $this->assertTrue($response);
+        $this->assertFileExists($file);
+        if(is_file($file))
+        {
+            $array = $this->readAsArray($file, Excel::XLSX);
+            $this->assertEquals($collection->collapse()->keys()->all(), collect($array)->first());
+        }
     }
 }

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -2,8 +2,8 @@
 
 namespace Maatwebsite\Excel\Tests\Mixins;
 
-use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Excel;
+use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Tests\TestCase;
 
 class StoreCollectionTest extends TestCase
@@ -46,8 +46,8 @@ class StoreCollectionTest extends TestCase
     public function can_store_a_collection_with_headings_as_excel()
     {
         $collection = new Collection([
-            ['column_1' => 'test','column_2' => 'test'],
-            ['column_1' => 'test','column_2' => 'test'],
+            ['column_1' => 'test', 'column_2' => 'test'],
+            ['column_1' => 'test', 'column_2' => 'test'],
         ]);
 
         $response = $collection->storeExcel('collection-headers-store.xlsx', null, Excel::XLSX, true);
@@ -56,8 +56,7 @@ class StoreCollectionTest extends TestCase
 
         $this->assertTrue($response);
         $this->assertFileExists($file);
-        if(is_file($file))
-        {
+        if (is_file($file)) {
             $array = $this->readAsArray($file, Excel::XLSX);
             $this->assertEquals($collection->collapse()->keys()->all(), collect($array)->first());
         }


### PR DESCRIPTION
### Requirements

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

Hello,

i've added withHeadings functionality to DownloadCollection and StoreCollection mixins,
as an additional parameter, to allow the use of collection keys in the header of the generated file.

### Why Should This Be Added?

It will make the collection mixins more useful, because i think header generation is a common use case.

### Possible Drawbacks

There is no breaking change.

### Verification Process

I added tests to check that it works. 

### Applicable Issues

It can be used to transform a collection into an excel file while using the keys of each collection element as columns. It's mainly useful when each elements of the collection share the same keys.

thanks.