### PR TITLE
change database testing to sqlite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,11 +11,6 @@
          syntaxCheck="true"
 >
     <php>
-        <env name="DB_HOST" value="127.0.0.1"/>
-        <env name="DB_PORT" value="3306"/>
-        <env name="DB_DATABASE" value="laravel_excel"/>
-        <env name="DB_USERNAME" value="root"/>
-        <env name="DB_PASSWORD" value=""/>
     </php>
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -65,13 +65,10 @@ class TestCase extends OrchestraTestCase
         ]);
 
         $app['config']->set('database.default', 'testing');
-        $app['config']->set('database.connections.testing', [
-            'driver'   => 'mysql',
-            'host'     => env('DB_HOST'),
-            'port'     => env('DB_PORT'),
-            'database' => env('DB_DATABASE'),
-            'username' => env('DB_USERNAME'),
-            'password' => env('DB_PASSWORD'),
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
         ]);
 
         $app['config']->set('view.paths', [


### PR DESCRIPTION
Hi, @brandondrew 
This is my first time to contribute to LaravelExcel, and i think better to change database testing from mysql to sqlite. Because you need create database before run the tests for the firs time. If you use sqlite, you don't need create it anymore.

Thanks