### PR TITLE
Allow Laravel 5.7.x releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
   "require": {
     "php": ">=5.5",
     "phpoffice/phpexcel": "^1.8.1",
-    "illuminate/cache": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
-    "illuminate/config": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
-    "illuminate/filesystem": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
-    "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+    "illuminate/cache": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+    "illuminate/config": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+    "illuminate/filesystem": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+    "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
     "jeremeamia/superclosure": "^2.3",
     "nesbot/carbon": "~1.0",
     "tijsverkoyen/css-to-inline-styles": "~2.0"


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

Allow newly released 5.7.x Laravel version to be used with this package

### Why Should This Be Added?

Users are limited to Laravel <= 5.6.x until this change is included

### Benefits

Allow users to use LAravel 5.7.x

### Possible Drawbacks

None

### Verification Process

Travis-CI

### Applicable Issues

The current failing tests are a branch 2.1 issue ( https://travis-ci.org/Maatwebsite/Laravel-Excel/builds/422302913 ), not specific to this PR
