### PR TITLE
Specify versions for Illuminate/Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": "^7.0",
     "phpoffice/phpspreadsheet": "^1.4",
-    "illuminate/support": "^5.5"
+    "illuminate/support": "5.5.* || 5.6.* || 5.7.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",


### PR DESCRIPTION

### Description of the Change

Modifying composer.json to specify Illuminate/Support package version.

### Why Should This Be Added?

This will prevent possible breaking changes in future versions of Laravel

### Benefits

Same as above, prevent possible future breaking changes because Laravel does not follow SemVer
