### PR TITLE
Start the progress bar from $startRow

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -205,6 +205,7 @@ class Sheet
 
         if ($import instanceof WithProgressBar) {
             $import->getConsoleOutput()->progressStart($this->worksheet->getHighestRow());
+            $import->getConsoleOutput()->progressAdvance($startRow - 1);
         }
 
         $calculatesFormulas = $import instanceof WithCalculatedFormulas;


### PR DESCRIPTION
### Description of the Change

When using `WithChunkReading` and `WithProgressBar` together, progress bars are wrong:

```
0 to 100 / 100 (0% to 100%)
0 to 100 jump to 200 / 200 (0% to 50% jump to 100%)
0 to 100 jump to 300 / 300 (0% to 33% jump to 100%)
```

We now advance the progress bar to `$startRow - 1` right at the beginning to have:

```
0 to 100 / 100 (0% to 100%)
100 to 200 / 200 (50% to 100%)
200 to 300 / 300 (66% to 100%)
```

We start from `$startRow - 1` to avoid going to `201 / 201`.

### Possible Drawbacks

Percentages are correct but the timing is still wrong (during the third progress bar, 66% to 100% is as long as the first progress bar from 0% to 100%). Maybe a future PR could fix the progress bar a bit more. Or I could make the change if someone tell me what behavior is wanted.

Easy to do:

```
0 to 100 / 100 (0% to 100%)
0 to 100 / 100 (0% to 100%)
0 to 100 / 100 (0% to 100%)
```

Or, second possibility, but not sure if it's possible to end the progress bar without jumping to 100%:

```
0 to 100 / 300 (0% to 33%)
100 to 200 / 300 (33% to 66%)
200 to 300 / 300 (66% to 100%)
```

