### PR TITLE
Make database transaction optional

### DIFF
--- a/src/Concerns/WithTransactions.php
+++ b/src/Concerns/WithTransactions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithTransactions
+{
+    /**
+     * @return int
+     */
+    public function useTransaction(): bool;
+}


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [+] Checked the codebase to ensure that your feature doesn't already exist.
* [+] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [] Adjusted the Documentation.
* [+] Added tests to ensure against regression.

### Description of the Change
Add new interface "withTransactions" soo user can toggle using transactions while importing

### Why Should This Be Added?

Database transactions are great if you have to import a file with unique data/attributes. But when you have a large file with duplicates. Then It's good to have an option to disable transactions and process import with catching exceptions

### Benefits

* More flexibility on handling large files

### Possible Drawbacks

--
