### PR TITLE
Add "afterImport" event to events.

### DIFF
--- a/src/Concerns/RegistersEventListeners.php
+++ b/src/Concerns/RegistersEventListeners.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
+use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\AfterSheet;
 use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Events\BeforeExport;
@@ -27,6 +28,10 @@ trait RegistersEventListeners
 
         if (method_exists($this, 'beforeImport')) {
             $listeners[BeforeImport::class] = [static::class, 'beforeImport'];
+        }
+
+        if (method_exists($this, 'afterImport')) {
+            $listeners[AfterImport::class] = [static::class, 'afterImport'];
         }
 
         if (method_exists($this, 'beforeSheet')) {

--- a/src/Concerns/RegistersEventListeners.php
+++ b/src/Concerns/RegistersEventListeners.php
@@ -2,8 +2,8 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
-use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\AfterSheet;
+use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Events\BeforeExport;
 use Maatwebsite\Excel\Events\BeforeImport;

--- a/src/Events/AfterImport.php
+++ b/src/Events/AfterImport.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Maatwebsite\Excel\Events;
+
+use Maatwebsite\Excel\Reader;
+
+class AfterImport extends Event
+{
+    /**
+     * @var Reader
+     */
+    public $reader;
+
+    /**
+     * @var object
+     */
+    private $importable;
+
+    /**
+     * @param Reader $reader
+     * @param object $importable
+     */
+    public function __construct(Reader $reader, $importable)
+    {
+        $this->reader     = $reader;
+        $this->importable = $importable;
+    }
+
+    /**
+     * @return Reader
+     */
+    public function getReader(): Reader
+    {
+        return $this->reader;
+    }
+
+    /**
+     * @return object
+     */
+    public function getConcernable()
+    {
+        return $this->importable;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDelegate()
+    {
+        return $this->reader;
+    }
+}

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -92,7 +92,6 @@ class Reader
             $sheet->disconnect();
         }
 
-
         $this->afterReading($import);
         $this->garbageCollect();
 
@@ -122,7 +121,6 @@ class Reader
             $sheets[$index] = $sheet->toArray($sheetImport, $sheet->getStartRow($sheetImport));
             $sheet->disconnect();
         }
-
 
         $this->afterReading($import);
         $this->garbageCollect();
@@ -313,7 +311,6 @@ class Reader
      */
     private function afterReading($import)
     {
-
         $this->raise(new AfterImport($this, $import));
     }
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -311,7 +311,8 @@ class Reader
     /**
      * @param object $import
      */
-    private function afterReading($import){
+    private function afterReading($import)
+    {
 
         $this->raise(new AfterImport($this, $import));
     }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -4,9 +4,9 @@ namespace Maatwebsite\Excel;
 
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
-use Maatwebsite\Excel\Events\AfterImport;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Reader\Csv;
+use Maatwebsite\Excel\Events\AfterImport;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\BeforeImport;

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -4,6 +4,7 @@ namespace Maatwebsite\Excel;
 
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Events\AfterImport;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Reader\Csv;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
@@ -91,6 +92,8 @@ class Reader
             $sheet->disconnect();
         }
 
+
+        $this->afterReading($import);
         $this->garbageCollect();
 
         return $this;
@@ -120,6 +123,8 @@ class Reader
             $sheet->disconnect();
         }
 
+
+        $this->afterReading($import);
         $this->garbageCollect();
 
         return $sheets;
@@ -149,6 +154,7 @@ class Reader
             $sheet->disconnect();
         }
 
+        $this->afterReading($import);
         $this->garbageCollect();
 
         return $sheets;
@@ -300,5 +306,13 @@ class Reader
         }
 
         $this->raise(new BeforeImport($this, $import));
+    }
+
+    /**
+     * @param object $import
+     */
+    private function afterReading($import){
+
+        $this->raise(new AfterImport($this, $import));
     }
 }

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -2,13 +2,13 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Excel;
 use Maatwebsite\Excel\Sheet;
 use Maatwebsite\Excel\Reader;
 use Maatwebsite\Excel\Writer;
 use Maatwebsite\Excel\Tests\TestCase;
 use Maatwebsite\Excel\Events\AfterSheet;
+use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Events\BeforeExport;

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
+use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Excel;
 use Maatwebsite\Excel\Sheet;
 use Maatwebsite\Excel\Reader;
@@ -74,6 +75,12 @@ class WithEventsTest extends TestCase
             $eventsTriggered++;
         };
 
+        $event->afterImport = function ($event) use (&$eventsTriggered) {
+            $this->assertInstanceOf(AfterImport::class, $event);
+            $this->assertInstanceOf(Reader::class, $event->getReader());
+            $eventsTriggered++;
+        };
+
         $event->beforeSheet = function ($event) use (&$eventsTriggered) {
             $this->assertInstanceOf(BeforeSheet::class, $event);
             $this->assertInstanceOf(Sheet::class, $event->getSheet());
@@ -87,7 +94,7 @@ class WithEventsTest extends TestCase
         };
 
         $event->import('import.xlsx');
-        $this->assertEquals(3, $eventsTriggered);
+        $this->assertEquals(4, $eventsTriggered);
     }
 
     /**

--- a/tests/Data/Stubs/ExportWithRegistersEventListeners.php
+++ b/tests/Data/Stubs/ExportWithRegistersEventListeners.php
@@ -18,6 +18,13 @@ class ExportWithRegistersEventListeners implements WithEvents
     /**
      * @var callable
      */
+
+    public static $afterExport;
+
+    /**
+     * @var callable
+     */
+
     public static $beforeWriting;
 
     /**

--- a/tests/Data/Stubs/ExportWithRegistersEventListeners.php
+++ b/tests/Data/Stubs/ExportWithRegistersEventListeners.php
@@ -18,13 +18,6 @@ class ExportWithRegistersEventListeners implements WithEvents
     /**
      * @var callable
      */
-
-    public static $afterExport;
-
-    /**
-     * @var callable
-     */
-
     public static $beforeWriting;
 
     /**

--- a/tests/Data/Stubs/ImportWithEvents.php
+++ b/tests/Data/Stubs/ImportWithEvents.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
+use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\AfterSheet;
 use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Concerns\Importable;
@@ -34,11 +35,14 @@ class ImportWithEvents implements WithEvents
     {
         return [
             BeforeImport::class => $this->beforeImport ?? function () {
-            },
-            BeforeSheet::class  => $this->beforeSheet ?? function () {
-            },
-            AfterSheet::class   => $this->afterSheet ?? function () {
-            },
+                },
+
+            AfterImport::class => $this->afterImport ?? function () {
+                },
+            BeforeSheet::class => $this->beforeSheet ?? function () {
+                },
+            AfterSheet::class => $this->afterSheet ?? function () {
+                },
         ];
     }
 }

--- a/tests/Data/Stubs/ImportWithEvents.php
+++ b/tests/Data/Stubs/ImportWithEvents.php
@@ -35,20 +35,12 @@ class ImportWithEvents implements WithEvents
     {
         return [
             BeforeImport::class => $this->beforeImport ?? function () {
-
-
             },
             AfterImport::class => $this->afterImport ?? function () {
-
-
             },
             BeforeSheet::class => $this->beforeSheet ?? function () {
-
-
             },
             AfterSheet::class => $this->afterSheet ?? function () {
-
-
             },
         ];
     }

--- a/tests/Data/Stubs/ImportWithEvents.php
+++ b/tests/Data/Stubs/ImportWithEvents.php
@@ -36,7 +36,6 @@ class ImportWithEvents implements WithEvents
         return [
             BeforeImport::class => $this->beforeImport ?? function () {
                 },
-
             AfterImport::class => $this->afterImport ?? function () {
                 },
             BeforeSheet::class => $this->beforeSheet ?? function () {

--- a/tests/Data/Stubs/ImportWithEvents.php
+++ b/tests/Data/Stubs/ImportWithEvents.php
@@ -2,8 +2,8 @@
 
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
-use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\AfterSheet;
+use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\WithEvents;
@@ -35,12 +35,16 @@ class ImportWithEvents implements WithEvents
     {
         return [
             BeforeImport::class => $this->beforeImport ?? function () {
+
                 },
             AfterImport::class => $this->afterImport ?? function () {
+
                 },
             BeforeSheet::class => $this->beforeSheet ?? function () {
+
                 },
             AfterSheet::class => $this->afterSheet ?? function () {
+
                 },
         ];
     }

--- a/tests/Data/Stubs/ImportWithEvents.php
+++ b/tests/Data/Stubs/ImportWithEvents.php
@@ -36,16 +36,20 @@ class ImportWithEvents implements WithEvents
         return [
             BeforeImport::class => $this->beforeImport ?? function () {
 
-                },
+
+            },
             AfterImport::class => $this->afterImport ?? function () {
 
-                },
+
+            },
             BeforeSheet::class => $this->beforeSheet ?? function () {
 
-                },
+
+            },
             AfterSheet::class => $this->afterSheet ?? function () {
 
-                },
+
+            },
         ];
     }
 }


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

<!--

This adds an "After Import" event that triggers an event after a job has completed an import.

-->

### Why Should This Be Added?

Because it ties in neatly with the beforeImport event and adds a lot of flexibility to the repo.

### Benefits

This is useful to do things like deleting a temporary file that was used on import, or to trigger a websocket connection to indicate that the import is complete.

### Possible Drawbacks

None that I can think of 

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

I have used it in a dev, staging and production environment and I have run all tests both for the included ones as well as in my own app.

-->

### Applicable Issues

<!-- Enter any applicable Issues here -->
