### PR TITLE
TmpFile must have ext for tsv or more.

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -208,9 +208,9 @@ class Reader
     {
         $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
         /** 
-         * if $ext == 'tsv', change 'csv'
-         */ 
-        $ext = strlen($ext) > 0 ? '.'.($ext === 'tsv' ? 'csv' : $ext) : '';
+         * if $ext == 'tsv', change 'csv'.
+         */
+        $ext = strlen($ext) > 0 ? '.' . ($ext === 'tsv' ? 'csv' : $ext) : '';
 
         return $this->tmpPath . DIRECTORY_SEPARATOR . str_random(16) . $ext;
     }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -207,7 +207,7 @@ class Reader
     protected function getTmpFile($filePath): string
     {
         $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
-        /** 
+        /**
          * if $ext == 'tsv', change 'csv'.
          */
         $ext = strlen($ext) > 0 ? '.' . ($ext === 'tsv' ? 'csv' : $ext) : '';

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -185,7 +185,7 @@ class Reader
      */
     protected function copyToFileSystem($filePath, string $disk = null)
     {
-        $tempFilePath = $this->getTmpFile();
+        $tempFilePath = $this->getTmpFile($filePath);
 
         if ($filePath instanceof UploadedFile) {
             return $filePath->move($tempFilePath)->getRealPath();
@@ -204,9 +204,15 @@ class Reader
     /**
      * @return string
      */
-    protected function getTmpFile(): string
+    protected function getTmpFile($filePath): string
     {
-        return $this->tmpPath . DIRECTORY_SEPARATOR . str_random(16);
+        $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+        /** 
+         * if $ext == 'tsv', change 'csv'
+         */ 
+        $ext = strlen($ext) > 0 ? '.'.($ext === 'tsv' ? 'csv' : $ext) : '';
+
+        return $this->tmpPath . DIRECTORY_SEPARATOR . str_random(16) . $ext;
     }
 
     /**


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change
### Why Should This Be Added?

I am not good at English. Please understand.

I Want to import tsv file 'title.akas.tsv' on [imdb sample data](https://datasets.imdbws.com)
But tsv is processing like csv, so tsv extension file can't passing.

'title.akas.tsv' mime type detected as 'application/octet-stream'. maybe this file contains 'utf-8' chareset string and multi country language.
in 'vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Reader/Csv.php', 'canRead' function is incorrent at sometime. 'mime_content_type' in 'canRead' is unsafe.

so. tmpfile must have extension. 

### Benefits

tsv or csv extension file import is very well.

### Possible Drawbacks

It looks absent.

### Verification Process

None

### Applicable Issues

<!-- Enter any applicable Issues here -->
