### PR TITLE
Made conditional sheets import possible

### DIFF
--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -84,7 +84,7 @@ class ChunkReader
         $worksheets     = [];
         $worksheetNames = $reader->listWorksheetNames($file);
         if ($import instanceof WithMultipleSheets) {
-            $sheetImports = $import->sheets();
+            $sheetImports = $import->sheets($worksheetNames);
 
             // Load specific sheets.
             if (method_exists($reader, 'setLoadSheetsOnly')) {

--- a/src/Concerns/WithMultipleSheets.php
+++ b/src/Concerns/WithMultipleSheets.php
@@ -2,12 +2,10 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
-
 interface WithMultipleSheets
 {
     /**
      * @return array
      */
-    public function sheets(Spreadsheet $spreadsheet): array;
+    public function sheets(array $worksheetNames): array;
 }

--- a/src/Concerns/WithMultipleSheets.php
+++ b/src/Concerns/WithMultipleSheets.php
@@ -2,10 +2,12 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
 interface WithMultipleSheets
 {
     /**
      * @return array
      */
-    public function sheets(): array;
+    public function sheets(Spreadsheet $spreadsheet): array;
 }

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -50,7 +50,7 @@ class QueueExport implements ShouldQueue
 
         $sheetExports = [$this->export];
         if ($this->export instanceof WithMultipleSheets) {
-            $sheetExports = $this->export->sheets();
+            $sheetExports = $this->export->sheets($writer->getDelegate()->getAllSheets());
         }
 
         // Pre-create the worksheets

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -67,7 +67,8 @@ class QueuedWriter
     {
         $sheetExports = [$export];
         if ($export instanceof WithMultipleSheets) {
-            $sheetExports = $export->sheets($this->writer->getDelegate()->getAllSheets());
+            $worksheetNames = $this->writer->getDelegate() ? $this->writer->getDelegate()->getAllSheets() : [];
+            $sheetExports   = $export->sheets($worksheetNames);
         }
 
         $jobs = new Collection;

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -67,7 +67,7 @@ class QueuedWriter
     {
         $sheetExports = [$export];
         if ($export instanceof WithMultipleSheets) {
-            $sheetExports = $export->sheets();
+            $sheetExports = $export->sheets($this->writer->getDelegate()->getAllSheets());
         }
 
         $jobs = new Collection;

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -236,7 +236,7 @@ class Reader
     {
         $sheetImports = [];
         if ($import instanceof WithMultipleSheets) {
-            $sheetImports = $import->sheets($this->spreadsheet);
+            $sheetImports = $import->sheets($this->spreadsheet->getAllSheets());
 
             if (method_exists($reader, 'setLoadSheetsOnly')) {
                 $reader->setLoadSheetsOnly(array_keys($sheetImports));

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -236,7 +236,7 @@ class Reader
     {
         $sheetImports = [];
         if ($import instanceof WithMultipleSheets) {
-            $sheetImports = $import->sheets();
+            $sheetImports = $import->sheets($this->spreadsheet);
 
             if (method_exists($reader, 'setLoadSheetsOnly')) {
                 $reader->setLoadSheetsOnly(array_keys($sheetImports));
@@ -300,9 +300,9 @@ class Reader
      */
     private function beforeReading($import, IReader $reader)
     {
-        $this->sheetImports = $this->buildSheetImports($import, $reader);
-
         $this->spreadsheet = $reader->load($this->currentFile);
+
+        $this->sheetImports = $this->buildSheetImports($import, $reader);
 
         // When no multiple sheets, use the main import object
         // for each loaded sheet in the spreadsheet

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -65,7 +65,7 @@ class Writer
 
         $sheetExports = [$export];
         if ($export instanceof WithMultipleSheets) {
-            $sheetExports = $export->sheets();
+            $sheetExports = $export->sheets($this->spreadsheet->getAllSheets());
         }
 
         foreach ($sheetExports as $sheetExport) {

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -36,12 +36,12 @@ class FromCollectionTest extends TestCase
 
         $this->assertTrue($response);
 
-        foreach ($export->sheets() as $sheetIndex => $sheet) {
-            $spreadsheet = $this->read(
-                __DIR__ . '/../Data/Disks/Local/multiple-sheets-collection-store.xlsx',
-                'Xlsx'
-            );
+        $spreadsheet = $this->read(
+            __DIR__ . '/../Data/Disks/Local/multiple-sheets-collection-store.xlsx',
+            'Xlsx'
+        );
 
+        foreach ($export->sheets($spreadsheet->getAllSheets()) as $sheetIndex => $sheet) {
             $worksheet = $spreadsheet->getSheet($sheetIndex);
 
             $this->assertEquals($sheet->collection()->toArray(), $worksheet->toArray());

--- a/tests/Concerns/FromViewTest.php
+++ b/tests/Concerns/FromViewTest.php
@@ -101,7 +101,7 @@ class FromViewTest extends TestCase
             /**
              * @return SheetForUsersFromView[]
              */
-            public function sheets() : array
+            public function sheets(array $worksheetNames) : array
             {
                 return [
                     new SheetForUsersFromView($this->users->forPage(1, 100)),

--- a/tests/Concerns/WithChunkReadingTest.php
+++ b/tests/Concerns/WithChunkReadingTest.php
@@ -303,7 +303,7 @@ class WithChunkReadingTest extends TestCase
             /**
              * @return array
              */
-            public function sheets(): array
+            public function sheets(array $worksheetNames): array
             {
                 return [
                     new class implements ToModel, WithBatchInserts {

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -36,7 +36,7 @@ class WithMultipleSheetsTest extends TestCase
             /**
              * @return SheetWith100Rows[]
              */
-            public function sheets() : array
+            public function sheets(array $worksheetNames) : array
             {
                 return [
                     new SheetWith100Rows('A'),
@@ -80,7 +80,7 @@ class WithMultipleSheetsTest extends TestCase
             /**
              * @return SheetForUsersFromView[]
              */
-            public function sheets() : array
+            public function sheets(array $worksheetNames) : array
             {
                 return [
                     new SheetForUsersFromView($this->users->forPage(1, 100)),
@@ -105,7 +105,7 @@ class WithMultipleSheetsTest extends TestCase
         $import = new class implements WithMultipleSheets {
             use Importable;
 
-            public function sheets(): array
+            public function sheets(array $worksheetNames): array
             {
                 return [
                     new class implements ToArray {
@@ -141,7 +141,7 @@ class WithMultipleSheetsTest extends TestCase
         $import = new class implements WithMultipleSheets {
             use Importable;
 
-            public function sheets(): array
+            public function sheets(array $worksheetNames): array
             {
                 return [
                     'Sheet2' => new class implements ToArray {

--- a/tests/Data/Stubs/QueuedExport.php
+++ b/tests/Data/Stubs/QueuedExport.php
@@ -12,7 +12,7 @@ class QueuedExport implements WithMultipleSheets
     /**
      * @return SheetWith100Rows[]
      */
-    public function sheets(): array
+    public function sheets(array $worksheetNames): array
     {
         return [
             new SheetWith100Rows('A'),

--- a/tests/Data/Stubs/ShouldQueueExport.php
+++ b/tests/Data/Stubs/ShouldQueueExport.php
@@ -13,7 +13,7 @@ class ShouldQueueExport implements WithMultipleSheets, ShouldQueue
     /**
      * @return SheetWith100Rows[]
      */
-    public function sheets(): array
+    public function sheets(array $worksheetNames): array
     {
         return [
             new SheetWith100Rows('A'),


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, 
the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have 
worked with the code here recently, so please walk us through the concepts.

-->

### Why Should This Be Added?

Importing variable number of sheets is not possible now.

### Benefits

We can easily decide which sheets are being imported. Eg:

```
namespace Budgets\Imports;

use Budgets\Imports\BudgetPlan\CostPlanImport;
use Budgets\Imports\BudgetPlan\InvestmentPlanImport;
use Budgets\Imports\BudgetPlan\ProjectPlanImport;
use Budgets\Imports\BudgetPlan\RenovationPlanImport;
use Budgets\Models\BudgetPlan;
use Maatwebsite\Excel\Concerns\WithMultipleSheets;
use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
use Maatwebsite\Excel\Concerns\Importable;

class BudgetPlanImport implements WithMultipleSheets, WithCalculatedFormulas
{
    use Importable;

    /**
     * @var BudgetPlan 
     */
    public $budgetPlan;

    /**
     * @var array
     */
    public $sheetClassMap = [
        'Investment Plan' => InvestmentPlanImport::class,
        'Cost Plan' => CostPlanImport::class,
        'Projects Plan' => ProjectPlanImport::class,
        'Renovation Plan' => RenovationPlanImport::class,
    ];

    /**
     * @var array
     */
    public $activeSheets = [];

    public function __construct(BudgetPlan $budgetPlan)
    {
        $this->budgetPlan = $budgetPlan;

        return $this;
    }

    public function sheets(array $worksheetNames): array
    {
        foreach($worksheetNames AS $worksheet) {
            if (isset($this->sheetClassMap[$worksheet->getTitle()])) {
                // This is the case when you need instance with constructor args, otherwise just pass class name
                $className = $this->sheetClassMap[$worksheet->getTitle()];
                $this->activeSheets[$worksheet->getTitle()] = new $className($this->budgetPlan);
            }
        }

        return $this->activeSheets;
    }
}
```

### Possible Drawbacks

Could break BC. The WithMultipleSheets concern has new method signature.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

-->

### Applicable Issues

https://github.com/Maatwebsite/Laravel-Excel/issues/1870
