### PR TITLE
allow type to be null

### DIFF
--- a/src/Excel.php
+++ b/src/Excel.php
@@ -176,7 +176,7 @@ class Excel implements Exporter, Importer
      *
      * @return string|null
      */
-    protected function findTypeByExtension($fileName, string $type = null): string
+    protected function findTypeByExtension($fileName, string $type = null): ?string
     {
         if (null !== $type) {
             return $type;

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -107,6 +107,10 @@ class Excel implements Exporter, Importer
     {
         $writerType = $this->findTypeByExtension($filePath, $writerType);
 
+        if(!$writerType) {
+            throw new NoTypeDetectedException();
+        }
+
         return $this->queuedWriter->store($export, $filePath, $disk, $writerType);
     }
 
@@ -167,6 +171,10 @@ class Excel implements Exporter, Importer
     {
         $writerType = $this->findTypeByExtension($fileName, $writerType);
 
+        if(!$writerType) {
+            throw new NoTypeDetectedException();
+        }
+
         return $this->writer->export($export, $writerType);
     }
 
@@ -176,7 +184,7 @@ class Excel implements Exporter, Importer
      *
      * @return string|null
      */
-    protected function findTypeByExtension($fileName, string $type = null): string
+    protected function findTypeByExtension($fileName, string $type = null)
     {
         if (null !== $type) {
             return $type;
@@ -193,13 +201,7 @@ class Excel implements Exporter, Importer
             throw new NoTypeDetectedException();
         }
 
-        $extensionDetector = config('excel.extension_detector.' . strtolower($extension));
-
-        if (!$extensionDetector) {
-            throw new NoTypeDetectedException();
-        }
-
-        return $extensionDetector;
+        return config('excel.extension_detector.' . strtolower($extension));
     }
 
     /**

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -176,7 +176,7 @@ class Excel implements Exporter, Importer
      *
      * @return string|null
      */
-    protected function findTypeByExtension($fileName, string $type = null): ?string
+    protected function findTypeByExtension($fileName, string $type = null)
     {
         if (null !== $type) {
             return $type;

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -107,7 +107,7 @@ class Excel implements Exporter, Importer
     {
         $writerType = $this->findTypeByExtension($filePath, $writerType);
 
-        if(!$writerType) {
+        if (!$writerType) {
             throw new NoTypeDetectedException();
         }
 
@@ -171,7 +171,7 @@ class Excel implements Exporter, Importer
     {
         $writerType = $this->findTypeByExtension($fileName, $writerType);
 
-        if(!$writerType) {
+        if (!$writerType) {
             throw new NoTypeDetectedException();
         }
 

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -176,7 +176,7 @@ class Excel implements Exporter, Importer
      *
      * @return string|null
      */
-    protected function findTypeByExtension($fileName, string $type = null)
+    protected function findTypeByExtension($fileName, string $type = null): string
     {
         if (null !== $type) {
             return $type;
@@ -193,7 +193,13 @@ class Excel implements Exporter, Importer
             throw new NoTypeDetectedException();
         }
 
-        return config('excel.extension_detector.' . strtolower($extension));
+        $extensionDetector = config('excel.extension_detector.' . strtolower($extension));
+
+        if (!$extensionDetector) {
+            throw new NoTypeDetectedException();
+        }
+
+        return $extensionDetector;
     }
 
     /**

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -359,7 +359,7 @@ class ExcelTest extends TestCase
             }
         };
 
-        $this->SUT->import($import, UploadedFile::fake()->create('import'));
+        $this->SUT->import($import, UploadedFile::fake()->create('import.zip'));
     }
 
     /**


### PR DESCRIPTION
### Requirements

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

When importing a file with an unknown extension the following error is thrown instead of an `NoTypeDetectedException`. This prevents the error from being thrown, since it allows the method to return null. Therefore the method `Excel::getReaderType` throws the `NoTypeDetectedException` as expected.

### Why Should This Be Added?

To allow the expected outcome and prevent ugly errors.

### Benefits

Devs can catch the exception and don't have to catch the general Error.

### Possible Drawbacks

PHP 7.1 is required for nullable return types.

### Verification Process

-

### Applicable Issues

 #1908 
