### PR TITLE
Fix heading not being exported when using  queue

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -146,9 +146,9 @@ class Sheet
             if ($sheetExport instanceof WithCustomStartCell) {
                 $startCell = $sheetExport->startCell();
             }
-            if ($sheetExport instanceof ShouldQueue){
+            if ($sheetExport instanceof ShouldQueue) {
                 $this->append($sheetExport->headings(), $startCell ?? null, $this->hasStrictNullComparison($sheetExport));
-            }else{
+            } else {
                 $this->append([$sheetExport->headings()], $startCell ?? null, $this->hasStrictNullComparison($sheetExport));
             }
         }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -146,8 +146,11 @@ class Sheet
             if ($sheetExport instanceof WithCustomStartCell) {
                 $startCell = $sheetExport->startCell();
             }
-
-            $this->append([$sheetExport->headings()], $startCell ?? null, $this->hasStrictNullComparison($sheetExport));
+            if ($sheetExport instanceof ShouldQueue){
+                $this->append($sheetExport->headings(), $startCell ?? null, $this->hasStrictNullComparison($sheetExport));
+            }else{
+                $this->append([$sheetExport->headings()], $startCell ?? null, $this->hasStrictNullComparison($sheetExport));
+            }
         }
 
         if ($sheetExport instanceof WithCharts) {


### PR DESCRIPTION

* [X] Checked the codebase to ensure that your feature doesn't already exist.
* [X] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

Check whether the current sheet being open is using shouldQueue or not when trying to add the heading row.
For some reason, `queue()` is not reading the nested array for `$sheetExport->headings()`
whilst `store()` is. 
 
### Why Should This Be Added?

This ensures that when exporting `fromQueue` `withHeadings`, works exactly the same, whether using `queue()` or `store()`
 
### Benefits

Uniform behavior independent of using store or queue.

### Possible Drawbacks

There might be a better and more elegant way to fix this issue... though, over a quick iteration of the code, I could not find a quicker solution.

### Verification Process

As stated on issue #1921 - if you create a simple `fromQuery` exporter and try to use headings...
it should work both using the `store()` method and the `queue()` method.


### Applicable Issues
This addresses the problems raised in issue #1921
