### PR TITLE
Don't alter the fetchMode

### DIFF
--- a/src/Jobs/SerializedQuery.php
+++ b/src/Jobs/SerializedQuery.php
@@ -3,10 +3,8 @@
 namespace Maatwebsite\Excel\Jobs;
 
 use Illuminate\Database\Connection;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Events\StatementPrepared;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class SerializedQuery
@@ -52,10 +50,6 @@ class SerializedQuery
     {
         /** @var Connection $connection */
         $connection = app('db')->connection($this->connection);
-
-        Event::listen(StatementPrepared::class, function ($event) {
-            $event->statement->setFetchMode(\PDO::FETCH_ASSOC);
-        });
 
         return $this->hydrate(
             $connection->select($this->query, $this->bindings)


### PR DESCRIPTION
Issue #1923

### Requirements

* [X] Checked the codebase to ensure that your feature doesn't already exist.
* [X] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [X] Adjusted the Documentation.
* [X] Added tests to ensure against regression.

### Description of the Change

`SerializedQuery` registers an event listener on `StatementPrepared` for the lifetime of the application. This alters the behaviour of for example `QueryBuilder::get` in all parts of the app. 

### Why Should This Be Added?

The `fetchMode` shouldn't be altered. 

### Benefits

Queries return `stdClass`, as expected. 

### Possible Drawbacks

Probably, **performance loss**. 

### Verification Process

Let's see if all tests pass. ;)

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

-->

### Applicable Issues

#1923
