### PR TITLE
add exception for cases where a file extension is provided which is n…

### DIFF
--- a/src/Excel.php
+++ b/src/Excel.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel;
 
 use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Exceptions\InvalidFileType;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Filesystem\Factory;
@@ -193,7 +194,13 @@ class Excel implements Exporter, Importer
             throw new NoTypeDetectedException();
         }
 
-        return config('excel.extension_detector.' . strtolower($extension));
+        $detectedType = config('excel.extension_detector.' . strtolower($extension));
+
+        if (null === $detectedType) {
+            throw new InvalidFileType();
+        }
+
+        return $detectedType;
     }
 
     /**

--- a/src/Exceptions/InvalidFileType.php
+++ b/src/Exceptions/InvalidFileType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Maatwebsite\Excel\Exceptions;
+
+use Exception;
+use Throwable;
+
+class InvalidFileType extends Exception implements LaravelExcelException
+{
+    /**
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        $message = 'File type was not recognized or is unsupported. Make sure you either pass a valid extension to the filename or pass an explicit type.',
+        $code = 0,
+        Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -364,6 +364,28 @@ class ExcelTest extends TestCase
 
     /**
      * @test
+     * @expectedException \Maatwebsite\Excel\Exceptions\InvalidFileType
+     */
+    public function import_will_throw_error_when_file_type_is_not_supported()
+    {
+        $import = new class implements ToArray {
+            /**
+             * @param array $array
+             */
+            public function array(array $array)
+            {
+                Assert::assertEquals([
+                    ['test', 'test'],
+                    ['test', 'test'],
+                ], $array);
+            }
+        };
+
+        $this->SUT->import($import, UploadedFile::fake()->create('foo.wtf'));
+    }
+
+    /**
+     * @test
      */
     public function can_import_without_extension_with_explicit_reader_type()
     {


### PR DESCRIPTION
If a file extension exists but is not in the list of config options, you'll get this lovely error 
"return value of Maatwebsite\Excel\Excel::findTypeByExtension() must be of the type string, null returned"

This PR adds throwing an explicit exception in this case.