### PR TITLE
This should fix #1904 - do not try to execute chunkRead job if spreadsh…

### DIFF
--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -93,6 +93,11 @@ class ReadChunk implements ShouldQueue
             $this->sheetName
         );
 
+        if ($sheet->getHighestRow() < $this->startRow) {
+            $sheet->disconnect();
+            return;
+        }
+
         DB::transaction(function () use ($sheet) {
             $sheet->import(
                 $this->sheetImport,

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -95,6 +95,7 @@ class ReadChunk implements ShouldQueue
 
         if ($sheet->getHighestRow() < $this->startRow) {
             $sheet->disconnect();
+
             return;
         }
 


### PR DESCRIPTION
* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change
Importing a file with empty lines when using batches may result in throwing an error due to false info provided by phpsreadsheet reader.
This PR adds extra checking for out-of-bounds error when readChunk job is executed.

### Why Should This Be Added?
This should fix #1904 

### Benefits
Spreadsheet files with deleted rows now should be imported without exception.

### Possible Drawbacks
none

### Verification Process
* Manual testing with specific ODS file.
* https://travis-ci.org/chorry/Laravel-Excel/builds/483289783

### Applicable Issues
#1904 
