### PR TITLE
Import events with chunk reading

### DIFF
--- a/src/Concerns/RegistersEventListeners.php
+++ b/src/Concerns/RegistersEventListeners.php
@@ -8,6 +8,8 @@ use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Events\BeforeExport;
 use Maatwebsite\Excel\Events\BeforeImport;
 use Maatwebsite\Excel\Events\BeforeWriting;
+use Maatwebsite\Excel\Events\AfterChunkImport;
+use Maatwebsite\Excel\Events\BeforeChunkImport;
 
 trait RegistersEventListeners
 {
@@ -32,6 +34,14 @@ trait RegistersEventListeners
 
         if (method_exists($this, 'afterImport')) {
             $listeners[AfterImport::class] = [static::class, 'afterImport'];
+        }
+
+        if (method_exists($this, 'beforeChunkImport')) {
+            $listeners[BeforeChunkImport::class] = [static::class, 'beforeChunkImport'];
+        }
+
+        if (method_exists($this, 'afterChunkImport')) {
+            $listeners[AfterChunkImport::class] = [static::class, 'afterChunkImport'];
         }
 
         if (method_exists($this, 'beforeSheet')) {

--- a/src/Events/AfterChunkImport.php
+++ b/src/Events/AfterChunkImport.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Maatwebsite\Excel\Events;
+
+use PhpOffice\PhpSpreadsheet\Reader\IReader;
+
+class AfterChunkImport extends Event
+{
+    /**
+     * @var IReader
+     */
+    public $reader;
+
+    /**
+     * @var object
+     */
+    private $importable;
+
+    /**
+     * @param IReader $reader
+     * @param object $importable
+     */
+    public function __construct(IReader $reader, $importable)
+    {
+        $this->reader     = $reader;
+        $this->importable = $importable;
+    }
+
+    /**
+     * @return IReader
+     */
+    public function getReader(): IReader
+    {
+        return $this->reader;
+    }
+
+    /**
+     * @return object
+     */
+    public function getConcernable()
+    {
+        return $this->importable;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDelegate()
+    {
+        return $this->reader;
+    }
+}

--- a/src/Events/BeforeChunkImport.php
+++ b/src/Events/BeforeChunkImport.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Maatwebsite\Excel\Events;
+
+use PhpOffice\PhpSpreadsheet\Reader\IReader;
+
+class BeforeChunkImport extends Event
+{
+    /**
+     * @var IReader
+     */
+    public $reader;
+
+    /**
+     * @var object
+     */
+    private $importable;
+
+    /**
+     * @param IReader $reader
+     * @param object $importable
+     */
+    public function __construct(IReader $reader, $importable)
+    {
+        $this->reader     = $reader;
+        $this->importable = $importable;
+    }
+
+    /**
+     * @return IReader
+     */
+    public function getReader(): IReader
+    {
+        return $this->reader;
+    }
+
+    /**
+     * @return object
+     */
+    public function getConcernable()
+    {
+        return $this->importable;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDelegate()
+    {
+        return $this->reader;
+    }
+}

--- a/src/Jobs/EndChunkImport.php
+++ b/src/Jobs/EndChunkImport.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Jobs;
 
 use Illuminate\Bus\Queueable;
-use Maatwebsite\Excel\Reader;
 use Maatwebsite\Excel\HasEventBus;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/src/Jobs/EndChunkImport.php
+++ b/src/Jobs/EndChunkImport.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Maatwebsite\Excel\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Maatwebsite\Excel\Reader;
+use Maatwebsite\Excel\HasEventBus;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use PhpOffice\PhpSpreadsheet\Reader\IReader;
+use Maatwebsite\Excel\Events\AfterChunkImport;
+
+class EndChunkImport implements ShouldQueue
+{
+    use HasEventBus, Queueable;
+
+    /**
+     * @var IReader
+     */
+    private $reader;
+
+    /**
+     * @var object
+     */
+    private $import;
+
+    /**
+     * @param IReader $reader
+     * @param object      $import
+     */
+    public function __construct(IReader $reader, $import)
+    {
+        $this->reader = $reader;
+        $this->import = $import;
+    }
+
+    public function handle()
+    {
+        if ($this->import instanceof WithEvents) {
+            $this->registerListeners($this->import->registerEvents());
+        }
+
+        $this->raise(new AfterChunkImport($this->reader, $this->import));
+    }
+}

--- a/src/Jobs/StartChunkImport.php
+++ b/src/Jobs/StartChunkImport.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Maatwebsite\Excel\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Maatwebsite\Excel\HasEventBus;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use PhpOffice\PhpSpreadsheet\Reader\IReader;
+use Maatwebsite\Excel\Events\BeforeChunkImport;
+
+class StartChunkImport implements ShouldQueue
+{
+    use HasEventBus, Queueable;
+
+    /**
+     * @var IReader
+     */
+    private $reader;
+
+    /**
+     * @var object
+     */
+    private $import;
+
+    /**
+     * @param IReader $reader
+     * @param object      $import
+     */
+    public function __construct(IReader $reader, $import)
+    {
+        $this->reader = $reader;
+        $this->import = $import;
+    }
+
+    public function handle()
+    {
+        if ($this->import instanceof WithEvents) {
+            $this->registerListeners($this->import->registerEvents());
+        }
+
+        $this->raise(new BeforeChunkImport($this->reader, $this->import));
+    }
+}

--- a/tests/Concerns/WithChunkEventsTest.php
+++ b/tests/Concerns/WithChunkEventsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Tests\TestCase;
+use PhpOffice\PhpSpreadsheet\Reader\IReader;
+use Maatwebsite\Excel\Events\AfterChunkImport;
+use Maatwebsite\Excel\Events\BeforeChunkImport;
+use Maatwebsite\Excel\Tests\Data\Stubs\ImportWithChunkEvents;
+
+class WithChunkEventsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function import_chunk_events_get_called()
+    {
+        $event = new ImportWithChunkEvents();
+
+        $eventsTriggered = 0;
+
+        $event->beforeChunkImport = function ($event) use (&$eventsTriggered) {
+            $this->assertInstanceOf(BeforeChunkImport::class, $event);
+            $this->assertInstanceOf(IReader::class, $event->getReader());
+            $eventsTriggered++;
+        };
+
+        $event->afterChunkImport = function ($event) use (&$eventsTriggered) {
+            $this->assertInstanceOf(AfterChunkImport::class, $event);
+            $this->assertInstanceOf(IReader::class, $event->getReader());
+            $eventsTriggered++;
+        };
+
+        $event->import('import.xlsx');
+        $this->assertEquals(2, $eventsTriggered);
+    }
+}

--- a/tests/Data/Stubs/ImportWithChunkEvents.php
+++ b/tests/Data/Stubs/ImportWithChunkEvents.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\AfterChunkImport;
+use Maatwebsite\Excel\Events\BeforeChunkImport;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+
+class ImportWithChunkEvents implements WithChunkReading, WithEvents
+{
+    use Importable;
+
+    /**
+     * @var callable
+     */
+    public $beforeChunkImport;
+
+    /**
+     * @var callable
+     */
+    public $afterChunkImport;
+
+    /**
+     * @return array
+     */
+    public function registerEvents(): array
+    {
+        return [
+            BeforeChunkImport::class => $this->beforeChunkImport ?? function () {
+            },
+            AfterChunkImport::class => $this->afterChunkImport ?? function () {
+            },
+        ];
+    }
+
+    /**
+     * @return int
+     */
+    public function chunkSize(): int
+    {
+        return 100;
+    }
+
+    public static function beforeChunkImport()
+    {
+        (static::$beforeChunkImport)(...func_get_args());
+    }
+
+    public static function afterChunkImport()
+    {
+        (static::$afterChunkImport)(...func_get_args());
+    }
+}


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [X] Checked the codebase to ensure that your feature doesn't already exist.
* [X] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation. (TBD - see question below)
* [X] Added tests to ensure against regression.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, 
the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have 
worked with the code here recently, so please walk us through the concepts.

-->

Adds a single job to the beginning and end of the job chain for imports using the WithChunkReading concern, as discussed in #1944. The jobs fire a BeforeChunkImport and AfterChunkImport event, respectively.

### Why Should This Be Added?

<!-- Explain why this functionality should be added in Laravel-Excel -->
I can't speak to all use cases, but for implementations that require WithChunkReading for large imports, we need a way to identify when the chain is complete and perform any related functionality (such as an email notification). Imports that don't use chunk reading already raise a BeforeImport and AfterImport event, but this is not available for the chunked imports yet.

### Benefits

<!-- What benefits will be realized by the code change? -->

Users of the WithChunkReading concern can register listeners for the BeforeChunkImport and AfterChunkImport events to perform any custom functionality before or after a chunk reading import. The event class includes methods that allow you to access the underlying reader class and the import class, similar to the BeforeImport and AfterImport events.

(NOTE: The existing BeforeImport and AfterImport events could not be used, because they include the full Reader class in their payload, which cannot be serialized due to the inclusion of a Closure. The BeforeChunkImport and AfterChunkImport events here use the underlying PhpSpreadsheet class IReader instead.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts (e.g. breaking changes) of the code change? -->

@patrickbrouwers noted in #1944 that there would be a performance impact from two additional jobs in the chain. In testing this in my implementation, I found performance impact to be negligible.

I'd also like to note that I looked into adding the events to the first and last chunk jobs in the chain, rather than as separate jobs, but I found that to be problematic as the ReadChunk job doesn't include the original $import object. Open to suggestions though.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

-->

I wrote a test for a new import class that uses both WithChunkReading and WithEvents, modeled after existing event tests, and the full test suite ran smoothly. I also tested this branch in my project implementation, including using the RegistersEventListeners trait, and was able to do the post-import processing I needed using an afterChunkImport() method.

### Applicable Issues

<!-- Enter any applicable Issues here -->
#1944 [QUESTION] after import event

### Additional notes/questions

I may not have fully understood the intent of all the moving pieces here, and am happy to revise based on others' suggestions. My hope is to at least get the ball moving on a fix for the issue noted above, as this is critical to my implementation.

Also happy to update the docs, but I wasn't sure how thorough a change was needed there. Is it sufficient to add the BeforeChunkImport and AfterChunkImport options to the "Available Events" table  in the "Extending" page, or do we think this requires further explanation, or its own section on that page?