### PR TITLE
Handle array of array returned from map function for queued exports

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -496,10 +496,12 @@ class Sheet
                 $row = $sheetExport->map($row);
             }
 
+            $row = static::mapArraybleRow($row);
+
             if (isset($row[0]) && is_array($row[0])) {
-                $append[] = static::mapArraybleRow($row);
+                $append[] = $row;
             } else {
-                $append[] = [static::mapArraybleRow($row)];
+                $append[] = [$row];
             }
         }
         $append = array_merge(...$append);

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -490,14 +490,19 @@ class Sheet
      */
     public function appendRows($rows, $sheetExport)
     {
-        $append = [];
+        $append = [[]];
         foreach ($rows as $row) {
             if ($sheetExport instanceof WithMapping) {
                 $row = $sheetExport->map($row);
             }
 
-            $append[] = static::mapArraybleRow($row);
+            if (isset($row[0]) && is_array($row[0])) {
+                $append[] = static::mapArraybleRow($row);
+            } else {
+                $append[] = [static::mapArraybleRow($row)];
+            }
         }
+        $append = array_merge(...$append);
 
         if ($sheetExport instanceof WithCustomStartCell) {
             $startCell = $sheetExport->startCell();

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -8,6 +8,7 @@ use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExport;
+use Maatwebsite\Excel\Tests\Data\Stubs\FromNestedArraysQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromNonEloquentQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExportWithEagerLoad;
 
@@ -32,6 +33,14 @@ class FromQueryTest extends TestCase
 
         factory(User::class)->times(100)->create()->each(function (User $user) use ($group) {
             $user->groups()->save($group);
+        });
+
+        $group_two = factory(Group::class)->create([
+            'name' => 'Group 2',
+        ]);
+
+        factory(User::class)->times(5)->create()->each(function (User $user) use ($group_two) {
+            $user->groups()->save($group_two);
         });
     }
 
@@ -144,5 +153,55 @@ class FromQueryTest extends TestCase
         })->all();
 
         $this->assertEquals($allUsers, $contents);
+    }
+
+    /**
+     * @test
+     */
+    public function can_export_from_query_builder_with_nested_arrays()
+    {
+        $export = new FromNestedArraysQueryExport();
+
+        $response = $export->store('from-query-with-nested-arrays.xlsx');
+
+        $this->assertTrue($response);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-with-nested-arrays.xlsx', 'Xlsx');
+
+        $this->assertEquals($this->format_nested_arrays_expected_data($export->query()->get()), $contents);
+    }
+
+    /**
+     * @test
+     */
+    public function can_export_from_query_builder_with_nested_arrays_queued()
+    {
+        $export = new FromNestedArraysQueryExport();
+
+        $export->queue('from-query-with-nested-arrays.xlsx');
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-with-nested-arrays.xlsx', 'Xlsx');
+
+        $this->assertEquals($this->format_nested_arrays_expected_data($export->query()->get()), $contents);
+    }
+
+    protected function format_nested_arrays_expected_data($groups)
+    {
+        $expected = [];
+        foreach ($groups as $group) {
+            $group_row = [$group->name, ''];
+
+            foreach ($group->users as $key => $user) {
+                if ($key === 0) {
+                    $group_row[1] = $user->email;
+                    $expected[] = $group_row;
+                    continue;
+                }
+
+                $expected[] = ['', $user->email];
+            }
+        }
+
+        return $expected;
     }
 }

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -8,8 +8,8 @@ use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExport;
-use Maatwebsite\Excel\Tests\Data\Stubs\FromNestedArraysQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromNonEloquentQueryExport;
+use Maatwebsite\Excel\Tests\Data\Stubs\FromNestedArraysQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExportWithEagerLoad;
 
 class FromQueryTest extends TestCase
@@ -194,7 +194,7 @@ class FromQueryTest extends TestCase
             foreach ($group->users as $key => $user) {
                 if ($key === 0) {
                     $group_row[1] = $user->email;
-                    $expected[] = $group_row;
+                    $expected[]   = $group_row;
                     continue;
                 }
 

--- a/tests/Data/Stubs/FromNestedArraysQueryExport.php
+++ b/tests/Data/Stubs/FromNestedArraysQueryExport.php
@@ -2,12 +2,11 @@
 
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
-use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 use Illuminate\Database\Query\Builder;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\WithMapping;
-use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 
 class FromNestedArraysQueryExport implements FromQuery, WithMapping
 {
@@ -30,9 +29,9 @@ class FromNestedArraysQueryExport implements FromQuery, WithMapping
      */
     public function map($row): array
     {
-        $rows = [];
+        $rows    = [];
         $sub_row = [$row->name, ''];
-        $count = 0;
+        $count   = 0;
 
         foreach ($row->users as $user) {
             if ($count === 0) {

--- a/tests/Data/Stubs/FromNestedArraysQueryExport.php
+++ b/tests/Data/Stubs/FromNestedArraysQueryExport.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
+use Illuminate\Database\Query\Builder;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
+
+class FromNestedArraysQueryExport implements FromQuery, WithMapping
+{
+    use Exportable;
+
+    /**
+     * @return Builder
+     */
+    public function query()
+    {
+        $query = Group::with('users');
+
+        return $query;
+    }
+
+    /**
+     * @param Group $row
+     *
+     * @return array
+     */
+    public function map($row): array
+    {
+        $rows = [];
+        $sub_row = [$row->name, ''];
+        $count = 0;
+
+        foreach ($row->users as $user) {
+            if ($count === 0) {
+                $sub_row[1] = $user['email'];
+            } else {
+                $sub_row = ['', $user['email']];
+            }
+
+            $rows[] = $sub_row;
+            $count++;
+        }
+
+        if ($count === 0) {
+            $rows[] = $sub_row;
+        }
+
+        return $rows;
+    }
+}


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change
This adds support for handling array of arrays returned from map function for queued exports. This has been natively supported for non-queued exports for about a year, and this just brings queued exports level.

### Why Should This Be Added?
Queued and non-queued exports currently behave differently. This can lead to unexpected exceptions when queueing an export after running it non-queued.

### Benefits
Queued and non-queued exports perform similarly.

### Possible Drawbacks
None that I can think of.

### Verification Process
- Ran export that returned array of arrays in map() method for some rows.
- Worked when export was not queued.
- Ran same export using ShouldQueue trait.
- Exception was thrown and export failed.

### Applicable Issues
#1711 
