### PR TITLE
Allow passing of options to disk

### DIFF
--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -31,11 +31,12 @@ trait Exportable
      * @param string      $filePath
      * @param string|null $disk
      * @param string|null $writerType
+     * @param mixed       $diskOptions
      *
      * @throws NoFilePathGivenException
      * @return bool|PendingDispatch
      */
-    public function store(string $filePath = null, string $disk = null, string $writerType = null)
+    public function store(string $filePath = null, string $disk = null, string $writerType = null, $diskOptions = [])
     {
         $filePath = $filePath ?? $this->filePath ?? null;
 
@@ -47,7 +48,8 @@ trait Exportable
             $this,
             $filePath,
             $disk ?? $this->disk ?? null,
-            $writerType ?? $this->writerType ?? null
+            $writerType ?? $this->writerType ?? null,
+            $diskOptions ?? $this->diskOptions ?? []
         );
     }
 
@@ -55,11 +57,12 @@ trait Exportable
      * @param string|null $filePath
      * @param string|null $disk
      * @param string|null $writerType
+     * @param mixed       $diskOptions
      *
      * @throws NoFilePathGivenException
      * @return PendingDispatch
      */
-    public function queue(string $filePath = null, string $disk = null, string $writerType = null)
+    public function queue(string $filePath = null, string $disk = null, string $writerType = null, $diskOptions = [])
     {
         $filePath = $filePath ?? $this->filePath ?? null;
 
@@ -71,7 +74,8 @@ trait Exportable
             $this,
             $filePath,
             $disk ?? $this->disk ?? null,
-            $writerType ?? $this->writerType ?? null
+            $writerType ?? $this->writerType ?? null,
+            $diskOptions ?? $this->diskOptions ?? []
         );
     }
 

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -88,21 +88,21 @@ class Excel implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function store($export, string $filePath, string $disk = null, string $writerType = null)
+    public function store($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
     {
         if ($export instanceof ShouldQueue) {
-            return $this->queue($export, $filePath, $disk, $writerType);
+            return $this->queue($export, $filePath, $disk, $writerType, $diskOptions);
         }
 
         $file = $this->export($export, $filePath, $writerType);
 
-        return $this->filesystem->disk($disk)->put($filePath, fopen($file, 'r+'));
+        return $this->filesystem->disk($disk)->put($filePath, fopen($file, 'r+'), $diskOptions);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function queue($export, string $filePath, string $disk = null, string $writerType = null)
+    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
     {
         $writerType = $this->findTypeByExtension($filePath, $writerType);
 
@@ -110,7 +110,7 @@ class Excel implements Exporter, Importer
             throw new NoTypeDetectedException();
         }
 
-        return $this->queuedWriter->store($export, $filePath, $disk, $writerType);
+        return $this->queuedWriter->store($export, $filePath, $disk, $writerType, $diskOptions);
     }
 
     /**

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -23,20 +23,22 @@ interface Exporter
      * @param string      $filePath
      * @param string|null $disk
      * @param string      $writerType
+     * @param mixed       $diskOptions
      *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      * @return bool
      */
-    public function store($export, string $filePath, string $disk = null, string $writerType = null);
+    public function store($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = []);
 
     /**
      * @param object      $export
      * @param string      $filePath
      * @param string|null $disk
      * @param string      $writerType
+     * @param mixed       $diskOptions
      *
      * @return PendingDispatch
      */
-    public function queue($export, string $filePath, string $disk = null, string $writerType = null);
+    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = []);
 }

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -49,7 +49,7 @@ class ExcelFake implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function store($export, string $filePath, string $disk = null, string $writerType = null)
+    public function store($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
     {
         if ($export instanceof ShouldQueue) {
             return $this->queue($export, $filePath, $disk, $writerType);
@@ -63,7 +63,7 @@ class ExcelFake implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function queue($export, string $filePath, string $disk = null, string $writerType = null)
+    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
     {
         Queue::fake();
 


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

We store our files on S3 as private files. To do so, we need to pass an option to the S3 disk when storing the file. We were unable to find a way to do this in Laravel-Excel, so we have added the ability to pass disk options via the various store() methods.

I'll submit a PR to get the docs updated too.

### Why Should This Be Added?

It's useful for those of us who don't just want to use the default behaviour of the disk.

### Benefits

 See above.

### Possible Drawbacks

None that I can think of.

### Verification Process

I ran the Laravel-Excel unit tests to check that I haven't broken anything. I then installed my fork of Laravel-Excel into our app and verified that the files are being saved as 'private'.

I've not been able to figure out a way to write a unit test for this change because Laravel-Excel doesn't seem to be using the Storage facade, so there's no obvious way of mocking the disk to verify that the options are being passed to it. Any advice welcome...

### Applicable Issues


