### PR TITLE
Make download headers customizable

### DIFF
--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -12,11 +12,12 @@ trait Exportable
     /**
      * @param string      $fileName
      * @param string|null $writerType
+     * @param array       $headers
      *
      * @throws NoFilenameGivenException
      * @return \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    public function download(string $fileName = null, string $writerType = null)
+    public function download(string $fileName = null, string $writerType = null, array $headers = [])
     {
         $fileName = $fileName ?? $this->fileName ?? null;
 
@@ -24,7 +25,12 @@ trait Exportable
             throw new NoFilenameGivenException();
         }
 
-        return $this->getExporter()->download($this, $fileName, $writerType ?? $this->writerType ?? null);
+        return $this->getExporter()->download(
+            $this,
+            $fileName,
+            $writerType ?? $this->writerType ?? null,
+            $headers
+        );
     }
 
     /**

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -78,11 +78,12 @@ class Excel implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function download($export, string $fileName, string $writerType = null)
+    public function download($export, string $fileName, string $writerType = null, array $headers = [])
     {
         return response()->download(
             $this->export($export, $fileName, $writerType)->getLocalPath(),
-            $fileName
+            $fileName,
+            $headers
         )->deleteFileAfterSend(true);
     }
 

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -11,12 +11,13 @@ interface Exporter
      * @param object      $export
      * @param string|null $fileName
      * @param string      $writerType
+     * @param array       $headers
      *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      * @return BinaryFileResponse
      */
-    public function download($export, string $fileName, string $writerType = null);
+    public function download($export, string $fileName, string $writerType = null, array $headers = []);
 
     /**
      * @param object      $export

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -39,7 +39,7 @@ class ExcelFake implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function download($export, string $fileName, string $writerType = null)
+    public function download($export, string $fileName, string $writerType = null, array $headers = [])
     {
         $this->downloads[$fileName] = $export;
 

--- a/tests/Concerns/ExportableTest.php
+++ b/tests/Concerns/ExportableTest.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Http\Request;
+use Maatwebsite\Excel\Excel;
 use Maatwebsite\Excel\Tests\TestCase;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Illuminate\Contracts\Support\Responsable;
@@ -86,5 +87,23 @@ class ExportableTest extends TestCase
         $response = $export->toResponse(new Request());
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function has_customized_header()
+    {
+        $export = new class {
+            use Exportable;
+        };
+        $response = $export->download(
+            'name.csv',
+            Excel::CSV,
+            [
+                'Content-Type' => 'text/csv',
+            ]
+        );
+        $this->assertEquals('text/csv', $response->headers->get('Content-Type'));
     }
 }


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: ~~https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing~~ https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation. ~~<- will be done as soon as you signal to merge the pull request~~ (done)
* [x] Added tests to ensure against regression.

### Description of the Change

Before, CSV downloads would be sent with a mime type of 'text/plain'.
This made Firefox propose to open the file with a text editor instead of LibreOffice / Excel.

This change allows to send custom headers, including ['Content-Type' => 'text/csv'], to fix this pragmatically.

### Why Should This Be Added?

* I think, serving csv as `text/plain` instead of `text/csv` is a problem, it's most likely a common stake holder request to change the mime type
* It's hard to find an alternative workaround (requires some digging)
* The workaround without this fix would be a bit longwinded:

```php
	$response = Excel::download(
            new MyExport($data), "{$filename}.csv",
            \Maatwebsite\Excel\Excel::CSV
        );

	// send the correct mime type
        $response->headers->set('Content-Type', 'text/csv');

        return $response;
```

With this fix:

```php
	return Excel::download(
	    new MyExport($data), "{$filename}.csv",
            \Maatwebsite\Excel\Excel::CSV,
	    ['Content-Type' => 'text/csv']
        );
```

### Benefits

Shorter code, no need to find a workaround. Will be documented.

### Possible Drawbacks

Doesn't break the API. Doesn't change behavior.  Custom headers are optional.

Adding another optional parameter might make the API more complex than it needs to be. Maintaining the API with another optional parameter might be harder.

### Verification Process

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?

Tests.

- How did you verify that the change has not introduced any regressions?

Running all existing tests.

### Applicable Issues

none, afaik.

[Edit] 
updated the check mark for "Adjusted the Documentation"