### PR TITLE
Only open file in read-mode, because it's only going to be read.

### DIFF
--- a/src/Files/TemporaryFile.php
+++ b/src/Files/TemporaryFile.php
@@ -53,9 +53,9 @@ abstract class TemporaryFile
     public function copyFrom($filePath, string $disk = null): TemporaryFile
     {
         if ($filePath instanceof UploadedFile) {
-            $readStream = fopen($filePath->getRealPath(), 'rb+');
+            $readStream = fopen($filePath->getRealPath(), 'rb');
         } elseif ($disk === null && realpath($filePath) !== false) {
-            $readStream = fopen($filePath, 'rb+');
+            $readStream = fopen($filePath, 'rb');
         } else {
             $readStream = app('filesystem')->disk($disk)->readStream($filePath);
         }


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change
When reading from a file in order to create a temporary copy, open the file in 'read' mode instead of read/write.

### Why Should This Be Added?

See #2159 - opening in read/write mode can cause permissions errors.

### Benefits

Fewer permissions errors!

### Possible Drawbacks

### Verification Process

Imported a file which only has read permissions set. It worked.

### Applicable Issues

#2159 