### PR TITLE
Update PHP documentation of Excel facade to match the Maatwebsite\Excel\Excel class methods

### DIFF
--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -10,9 +10,9 @@ use Illuminate\Foundation\Bus\PendingDispatch;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 /**
- * @method static BinaryFileResponse download(object $export, string $fileName, string $writerType = null)
- * @method static bool store(object $export, string $filePath, string $disk = null, string $writerType = null)
- * @method static PendingDispatch queue(object $export, string $filePath, string $disk = null, string $writerType = null)
+ * @method static BinaryFileResponse download(object $export, string $fileName, string $writerType = null, array $headers = [])
+ * @method static bool store(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+ * @method static PendingDispatch queue(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
  * @method static BaseExcel import(object $import, string $filePath, string $disk = null, string $readerType = null)
  * @method static array toArray(object $import, string $filePath, string $disk = null, string $readerType = null)
  * @method static Collection toCollection(object $import, string $filePath, string $disk = null, string $readerType = null)


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [ ] Checked the codebase to ensure that your feature doesn't already exist.
* [ ] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

This pull request only adds mixing parameters for the facade documentation.

### Why Should This Be Added?

They were missing in documentation but are available on the `Maatwebsite\Excel\Excel` class.
This can create warning in IDEs and can disrupt people on the available parameters.

### Benefits

For example, no more warning when using the `$diskOptions` for the `store` method.

### Possible Drawbacks

No impacts since it is only a change in documentation and added parameters have default values.

### Verification Process

### Applicable Issues

