### PR TITLE
Add original file extension to temporary filename

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,11 +10,11 @@
          stopOnFailure="false"
 >
     <php>
-        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_HOST" value="10.0.2.2"/>
         <env name="DB_PORT" value="3306"/>
         <env name="DB_DATABASE" value="laravel_excel"/>
         <env name="DB_USERNAME" value="root"/>
-        <env name="DB_PASSWORD" value=""/>
+        <env name="DB_PASSWORD" value="root"/>
     </php>
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,11 +10,11 @@
          stopOnFailure="false"
 >
     <php>
-        <env name="DB_HOST" value="10.0.2.2"/>
+        <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="3306"/>
         <env name="DB_DATABASE" value="laravel_excel"/>
         <env name="DB_USERNAME" value="root"/>
-        <env name="DB_PASSWORD" value="root"/>
+        <env name="DB_PASSWORD" value=""/>
     </php>
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -17,6 +17,11 @@ class TemporaryFileFactory
     private $temporaryDisk;
 
     /**
+     * @var string|null
+     */
+    private $fileExtension;
+
+   /**
      * @param string|null $temporaryPath
      * @param string|null $temporaryDisk
      */
@@ -24,6 +29,14 @@ class TemporaryFileFactory
     {
         $this->temporaryPath = $temporaryPath;
         $this->temporaryDisk = $temporaryDisk;
+    }
+
+    /**
+     * @param string|null $fileExtension
+     */
+    public function setFileExtension(string $fileExtension)
+    {
+        $this->fileExtension = $fileExtension;
     }
 
     /**
@@ -73,6 +86,8 @@ class TemporaryFileFactory
      */
     private function generateFilename(): string
     {
-        return 'laravel-excel-' . Str::random(32);
+        $fileExtension = $this->fileExtension ? '.' . $this->fileExtension : '';
+
+        return 'laravel-excel-' . Str::random(32) . $fileExtension;
     }
 }

--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -17,11 +17,6 @@ class TemporaryFileFactory
     private $temporaryDisk;
 
     /**
-     * @var string|null
-     */
-    private $fileExtension;
-
-    /**
      * @param string|null $temporaryPath
      * @param string|null $temporaryDisk
      */
@@ -33,37 +28,33 @@ class TemporaryFileFactory
 
     /**
      * @param string|null $fileExtension
-     */
-    public function setFileExtension(string $fileExtension)
-    {
-        $this->fileExtension = $fileExtension;
-    }
-
-    /**
+     *
      * @return TemporaryFile
      */
-    public function make(): TemporaryFile
+    public function make(string $fileExtension = null): TemporaryFile
     {
         if (null !== $this->temporaryDisk) {
             return $this->makeRemote();
         }
 
-        return $this->makeLocal();
+        return $this->makeLocal(null, $fileExtension);
     }
 
     /**
      * @param string|null $fileName
      *
+     * @param string|null $fileExtension
+     *
      * @return LocalTemporaryFile
      */
-    public function makeLocal(string $fileName = null): LocalTemporaryFile
+    public function makeLocal(string $fileName = null, string $fileExtension = null): LocalTemporaryFile
     {
         if (!file_exists($this->temporaryPath) && !mkdir($concurrentDirectory = $this->temporaryPath) && !is_dir($concurrentDirectory)) {
             throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
         }
 
         return new LocalTemporaryFile(
-            $this->temporaryPath . DIRECTORY_SEPARATOR . ($fileName ?: $this->generateFilename())
+            $this->temporaryPath . DIRECTORY_SEPARATOR . ($fileName ?: $this->generateFilename($fileExtension))
         );
     }
 
@@ -82,12 +73,12 @@ class TemporaryFileFactory
     }
 
     /**
+     * @param string|null $fileExtension
+     *
      * @return string
      */
-    private function generateFilename(): string
+    private function generateFilename(string $fileExtension = null): string
     {
-        $fileExtension = $this->fileExtension ? '.' . $this->fileExtension : '';
-
-        return 'laravel-excel-' . Str::random(32) . $fileExtension;
+        return 'laravel-excel-' . Str::random(32) . ($fileExtension ? '.' . $fileExtension : '');
     }
 }

--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -21,7 +21,7 @@ class TemporaryFileFactory
      */
     private $fileExtension;
 
-   /**
+    /**
      * @param string|null $temporaryPath
      * @param string|null $temporaryDisk
      */

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -393,8 +393,8 @@ class Reader
             Cell::setValueBinder($import);
         }
 
-        $this->temporaryFileFactory->setFileExtension(pathinfo($filePath, PATHINFO_EXTENSION));
-        $temporaryFile     = $shouldQueue ? $this->temporaryFileFactory->make() : $this->temporaryFileFactory->makeLocal();
+        $fileExtension = pathinfo($filePath, PATHINFO_EXTENSION);
+        $temporaryFile     = $shouldQueue ? $this->temporaryFileFactory->make($fileExtension) : $this->temporaryFileFactory->makeLocal(null, $fileExtension);
         $this->currentFile = $temporaryFile->copyFrom(
             $filePath,
             $disk

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -393,6 +393,7 @@ class Reader
             Cell::setValueBinder($import);
         }
 
+        $this->temporaryFileFactory->setFileExtension(pathinfo($filePath, PATHINFO_EXTENSION));
         $temporaryFile     = $shouldQueue ? $this->temporaryFileFactory->make() : $this->temporaryFileFactory->makeLocal();
         $this->currentFile = $temporaryFile->copyFrom(
             $filePath,

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -393,7 +393,7 @@ class Reader
             Cell::setValueBinder($import);
         }
 
-        $fileExtension = pathinfo($filePath, PATHINFO_EXTENSION);
+        $fileExtension     = pathinfo($filePath, PATHINFO_EXTENSION);
         $temporaryFile     = $shouldQueue ? $this->temporaryFileFactory->make($fileExtension) : $this->temporaryFileFactory->makeLocal(null, $fileExtension);
         $this->currentFile = $temporaryFile->copyFrom(
             $filePath,

--- a/tests/Concerns/ImportableTest.php
+++ b/tests/Concerns/ImportableTest.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
+use Maatwebsite\Excel\Excel;
 use PHPUnit\Framework\Assert;
 use Maatwebsite\Excel\Importer;
 use Maatwebsite\Excel\Tests\TestCase;
@@ -56,5 +57,33 @@ class ImportableTest extends TestCase
         };
 
         $import->import($this->givenUploadedFile(__DIR__ . '/../Data/Disks/Local/import.xlsx'));
+    }
+
+    /**
+     * @test
+     */
+    public function can_import_a_simple_csv_file_with_html_tags_inside()
+    {
+        $import = new class implements ToArray
+        {
+            use Importable;
+
+            /**
+             * @param array $array
+             */
+            public function array(array $array)
+            {
+                Assert::assertEquals([
+                    ['key1', 'A', 'row1'],
+                    ['key2', 'B', '<p>row2</p>'],
+                    ['key3', 'C', 'row3',],
+                    ['key4', 'D', 'row4'],
+                    ['key5', 'E', 'row5'],
+                    ['key6', 'F', '<a href=/url-example">link</a>"'],
+                ], $array);
+            }
+        };
+
+        $import->import('csv-with-html-tags.csv', 'local', Excel::CSV);
     }
 }

--- a/tests/Concerns/ImportableTest.php
+++ b/tests/Concerns/ImportableTest.php
@@ -64,8 +64,7 @@ class ImportableTest extends TestCase
      */
     public function can_import_a_simple_csv_file_with_html_tags_inside()
     {
-        $import = new class implements ToArray
-        {
+        $import = new class implements ToArray {
             use Importable;
 
             /**
@@ -76,7 +75,7 @@ class ImportableTest extends TestCase
                 Assert::assertEquals([
                     ['key1', 'A', 'row1'],
                     ['key2', 'B', '<p>row2</p>'],
-                    ['key3', 'C', 'row3',],
+                    ['key3', 'C', 'row3'],
                     ['key4', 'D', 'row4'],
                     ['key5', 'E', 'row5'],
                     ['key6', 'F', '<a href=/url-example">link</a>"'],

--- a/tests/Data/Disks/Local/.gitignore
+++ b/tests/Data/Disks/Local/.gitignore
@@ -16,3 +16,4 @@
 !value-binder-import.xlsx
 !csv-with-other-delimiter.csv
 !unknown-reader-type.zip
+!csv-with-html-tags.csv

--- a/tests/Data/Disks/Local/csv-with-html-tags.csv
+++ b/tests/Data/Disks/Local/csv-with-html-tags.csv
@@ -1,0 +1,6 @@
+"key1","A","row1"
+"key2","B","<p>row2</p>"
+"key3","C","row3"
+"key4","D","row4"
+"key5","E","row5"
+"key6","F","<a href="/url-example">link</a>"


### PR DESCRIPTION
### Requirements

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

When generating a temporary file, PhpSpreadsheets can't use file format for validating file extension.

### Why Should This Be Added?

The file extension is the single way how we can import this file (PhpSpreadsheet already have this [function](https://github.com/PHPOffice/PhpSpreadsheet/blob/master/src/PhpSpreadsheet/Reader/Csv.php#L548)). The original file type is missing after generating a temporary file.
### Benefits

We allow developers to use validation file format by extension from PhpSpreadsheet

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts (e.g. breaking changes) of the code change? -->

### Verification Process

New test case with import file containing HTML tags is added

### Applicable Issues

#2160