### PR TITLE
Bugfix/remove support for import line ending

### DIFF
--- a/config/excel.php
+++ b/config/excel.php
@@ -71,10 +71,9 @@ return [
         'csv'         => [
             'delimiter'              => ',',
             'enclosure'              => '"',
-            'line_ending'            => PHP_EOL,
-            'use_bom'                => false,
-            'include_separator_line' => false,
-            'excel_compatibility'    => false,
+            'escape_character'      => '\\',
+            'contiguous'            => false,
+            'input_encoding'        => 'UTF-8',
         ],
     ],
 

--- a/config/excel.php
+++ b/config/excel.php
@@ -71,9 +71,9 @@ return [
         'csv'         => [
             'delimiter'              => ',',
             'enclosure'              => '"',
-            'escape_character'      => '\\',
-            'contiguous'            => false,
-            'input_encoding'        => 'UTF-8',
+            'escape_character'       => '\\',
+            'contiguous'             => false,
+            'input_encoding'         => 'UTF-8',
         ],
     ],
 


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://laravel-excel-docs.dev/docs/3.1/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [X] Checked the codebase to ensure that your feature doesn't already exist.
* [X] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [X] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change
Remove unsupported options from CSV imports config, added missing options.
Docs: https://github.com/Maatwebsite/laravel-excel-docs/pull/63

### Why Should This Be Added?
Better match PhpSpreadsheet options. E.g. `line_ending` doesn't work for imports.

### Benefits
Better match PhpSpreadsheet options

### Possible Drawbacks
Already published (incorrect) config files may be out-of-sync with the new one.

### Verification Process
* Checked `src/Factories/ReaderFactory.php`
* Checked `vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Reader/Csv.php`

### Applicable Issues
https://github.com/Maatwebsite/Laravel-Excel/issues/2260
