### PR TITLE
Assert filepath by regex

### DIFF
--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
  * @method static array toArray(object $import, string $filePath, string $disk = null, string $readerType = null)
  * @method static Collection toCollection(object $import, string $filePath, string $disk = null, string $readerType = null)
  * @method static PendingDispatch queueImport(object $import, string $filePath, string $disk = null, string $readerType = null)
+ * @method static void matchByRegex()
+ * @method static void doNotMatchByRegex()
  * @method static void assertDownloaded(string $fileName, callable $callback = null)
  * @method static void assertStored(string $filePath, string $disk = null, callable $callback = null)
  * @method static void assertQueued(string $filePath, string $disk = null, callable $callback = null)

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -37,6 +37,11 @@ class ExcelFake implements Exporter, Importer
     protected $imported = [];
 
     /**
+     * @var boolean
+     */
+    protected $matchByRegex = false;
+
+    /**
      * {@inheritdoc}
      */
     public function download($export, string $fileName, string $writerType = null, array $headers = [])
@@ -174,12 +179,62 @@ class ExcelFake implements Exporter, Importer
     }
 
     /**
+     * When asserting downloaded, stored, queued or imported, use regular expression
+     * to look for a matching file path
+     *
+     * @return void
+     */
+    public function matchByRegex()
+    {
+        $this->matchByRegex = true;
+    }
+
+    /**
+     * When asserting downloaded, stored, queued or imported, use regular string
+     * comparison for matching file path
+     *
+     * @return void
+     */
+
+    public function doNotMatchByRegex()
+    {
+        $this->matchByRegex = false;
+    }
+
+    /**
+     * Asserts that an array has a specified key and returns the key if successful.
+     * @see matchByRegex for more information about file path matching
+     *
+     * @param string    $key
+     * @param array     $array
+     * @param string    $message
+     *
+     * @return string
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     */
+    protected function assertArrayHasKey(string $key, array $disk, string $message = ''): string
+    {
+        if ($this->matchByRegex) {
+            $files = array_keys($disk);
+            $results = preg_grep($key, $files);
+            Assert::assertGreaterThan(0, count($results), $message);
+            Assert::assertEquals(1, count($results), "More than one result matches the file name expression '$key'.");
+            return $results[0];
+        }
+        Assert::assertArrayHasKey($key, $disk, $message);
+        return $key;
+    }
+
+    /**
      * @param string        $fileName
      * @param callable|null $callback
      */
     public function assertDownloaded(string $fileName, $callback = null)
     {
-        Assert::assertArrayHasKey($fileName, $this->downloads, sprintf('%s is not downloaded', $fileName));
+        $fileName = $this->assertArrayHasKey($fileName, $this->downloads, sprintf('%s is not downloaded', $fileName));
 
         $callback = $callback ?: function () {
             return true;
@@ -206,7 +261,7 @@ class ExcelFake implements Exporter, Importer
         $disk         = $disk ?? 'default';
         $storedOnDisk = $this->stored[$disk] ?? [];
 
-        Assert::assertArrayHasKey(
+        $filePath = $this->assertArrayHasKey(
             $filePath,
             $storedOnDisk,
             sprintf('%s is not stored on disk %s', $filePath, $disk)
@@ -237,7 +292,7 @@ class ExcelFake implements Exporter, Importer
         $disk          = $disk ?? 'default';
         $queuedForDisk = $this->queued[$disk] ?? [];
 
-        Assert::assertArrayHasKey(
+        $filePath = $this->assertArrayHasKey(
             $filePath,
             $queuedForDisk,
             sprintf('%s is not queued for export on disk %s', $filePath, $disk)
@@ -268,7 +323,7 @@ class ExcelFake implements Exporter, Importer
         $disk           = $disk ?? 'default';
         $importedOnDisk = $this->imported[$disk] ?? [];
 
-        Assert::assertArrayHasKey(
+        $filePath = $this->assertArrayHasKey(
             $filePath,
             $importedOnDisk,
             sprintf('%s is not stored on disk %s', $filePath, $disk)

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -195,39 +195,9 @@ class ExcelFake implements Exporter, Importer
      *
      * @return void
      */
-
     public function doNotMatchByRegex()
     {
         $this->matchByRegex = false;
-    }
-
-    /**
-     * Asserts that an array has a specified key and returns the key if successful.
-     * @see matchByRegex for more information about file path matching
-     *
-     * @param string    $key
-     * @param array     $array
-     * @param string    $message
-     *
-     * @return string
-     *
-     * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws Exception
-     */
-    protected function assertArrayHasKey(string $key, array $disk, string $message = ''): string
-    {
-        if ($this->matchByRegex) {
-            $files = array_keys($disk);
-            $results = preg_grep($key, $files);
-            Assert::assertGreaterThan(0, count($results), $message);
-            Assert::assertEquals(1, count($results), "More than one result matches the file name expression '$key'.");
-
-            return $results[0];
-        }
-        Assert::assertArrayHasKey($key, $disk, $message);
-
-        return $key;
     }
 
     /**
@@ -339,5 +309,34 @@ class ExcelFake implements Exporter, Importer
             $callback($importedOnDisk[$filePath]),
             "The file [{$filePath}] was not imported with the expected data."
         );
+    }
+
+    /**
+     * Asserts that an array has a specified key and returns the key if successful.
+     * @see matchByRegex for more information about file path matching
+     *
+     * @param string    $key
+     * @param array     $array
+     * @param string    $message
+     *
+     * @return string
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     */
+    protected function assertArrayHasKey(string $key, array $disk, string $message = ''): string
+    {
+        if ($this->matchByRegex) {
+            $files = array_keys($disk);
+            $results = preg_grep($key, $files);
+            Assert::assertGreaterThan(0, count($results), $message);
+            Assert::assertEquals(1, count($results), "More than one result matches the file name expression '$key'.");
+
+            return $results[0];
+        }
+        Assert::assertArrayHasKey($key, $disk, $message);
+
+        return $key;
     }
 }

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -328,7 +328,7 @@ class ExcelFake implements Exporter, Importer
     protected function assertArrayHasKey(string $key, array $disk, string $message = ''): string
     {
         if ($this->matchByRegex) {
-            $files = array_keys($disk);
+            $files   = array_keys($disk);
             $results = preg_grep($key, $files);
             Assert::assertGreaterThan(0, count($results), $message);
             Assert::assertEquals(1, count($results), "More than one result matches the file name expression '$key'.");

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -37,7 +37,7 @@ class ExcelFake implements Exporter, Importer
     protected $imported = [];
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $matchByRegex = false;
 
@@ -180,7 +180,7 @@ class ExcelFake implements Exporter, Importer
 
     /**
      * When asserting downloaded, stored, queued or imported, use regular expression
-     * to look for a matching file path
+     * to look for a matching file path.
      *
      * @return void
      */
@@ -191,7 +191,7 @@ class ExcelFake implements Exporter, Importer
 
     /**
      * When asserting downloaded, stored, queued or imported, use regular string
-     * comparison for matching file path
+     * comparison for matching file path.
      *
      * @return void
      */
@@ -222,9 +222,11 @@ class ExcelFake implements Exporter, Importer
             $results = preg_grep($key, $files);
             Assert::assertGreaterThan(0, count($results), $message);
             Assert::assertEquals(1, count($results), "More than one result matches the file name expression '$key'.");
+
             return $results[0];
         }
         Assert::assertArrayHasKey($key, $disk, $message);
+
         return $key;
     }
 

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -41,6 +41,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertDownloaded('downloaded-filename.csv', function (FromCollection $export) {
             return $export->collection()->contains('foo');
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertDownloaded('/\w{10}-\w{8}\.csv/');
     }
 
     /**
@@ -58,6 +60,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertStored('stored-filename.csv', 's3', function (FromCollection $export) {
             return $export->collection()->contains('foo');
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/');
     }
 
     /**
@@ -75,6 +79,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertStored('stored-filename.csv', function (FromCollection $export) {
             return $export->collection()->contains('foo');
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/');
     }
 
     /**
@@ -92,6 +98,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('queued-filename.csv', 's3', function (FromCollection $export) {
             return $export->collection()->contains('foo');
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }
 
     /**
@@ -110,6 +118,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('queued-filename.csv', 's3', function (FromCollection $export) {
             return $export->collection()->contains('foo');
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }
 
     /**
@@ -125,6 +135,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertImported('stored-filename.csv', 's3', function (ToModel $import) {
             return $import->model([]) instanceof User;
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertImported('/\w{6}-\w{8}\.csv/');
     }
 
     /**
@@ -140,6 +152,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertImported('import.xlsx', function (ToModel $import) {
             return $import->model([]) instanceof User;
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertImported('/\w{6}-\w{8}\.csv/');
     }
 
     /**
@@ -158,6 +172,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('queued-filename.csv', 's3', function (ToModel $import) {
             return $import->model([]) instanceof User;
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }
 
     /**
@@ -176,6 +192,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('queued-filename.csv', 's3', function (ToModel $import) {
             return $import->model([]) instanceof User;
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }
 
     /**
@@ -193,6 +211,8 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('queued-filename.csv', function (FromCollection $export) {
             return $export->collection()->contains('foo');
         });
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }
 
     /**

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -153,7 +153,7 @@ class ExcelFakeTest extends TestCase
             return $import->model([]) instanceof User;
         });
         ExcelFacade::matchByRegex();
-        ExcelFacade::assertImported('/\w{6}-\w{8}\.csv/');
+        ExcelFacade::assertImported('/\w{6}\.xlsx/');
     }
 
     /**

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -61,7 +61,7 @@ class ExcelFakeTest extends TestCase
             return $export->collection()->contains('foo');
         });
         ExcelFacade::matchByRegex();
-        ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/');
+        ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/', 's3');
     }
 
     /**
@@ -99,7 +99,7 @@ class ExcelFakeTest extends TestCase
             return $export->collection()->contains('foo');
         });
         ExcelFacade::matchByRegex();
-        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
+        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
 
     /**
@@ -119,7 +119,7 @@ class ExcelFakeTest extends TestCase
             return $export->collection()->contains('foo');
         });
         ExcelFacade::matchByRegex();
-        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
+        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
 
     /**
@@ -136,7 +136,7 @@ class ExcelFakeTest extends TestCase
             return $import->model([]) instanceof User;
         });
         ExcelFacade::matchByRegex();
-        ExcelFacade::assertImported('/\w{6}-\w{8}\.csv/');
+        ExcelFacade::assertImported('/\w{6}-\w{8}\.csv/', 's3');
     }
 
     /**
@@ -173,7 +173,7 @@ class ExcelFakeTest extends TestCase
             return $import->model([]) instanceof User;
         });
         ExcelFacade::matchByRegex();
-        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
+        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
 
     /**
@@ -193,7 +193,7 @@ class ExcelFakeTest extends TestCase
             return $import->model([]) instanceof User;
         });
         ExcelFacade::matchByRegex();
-        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
+        ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
 
     /**


### PR DESCRIPTION
Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

Implements the ability to test file name/path using a regular expression.

### Why Should This Be Added?

While testing, if you a project uses dynamic file names, it is then possible to match against a pattern representing the file naming strategy. 

### Benefits

Makes testing easier.

### Possible Drawbacks

When more than one file/path matches the regex, it is not possible to perform the test, therefore the behaviour is to fail. 

### Verification Process

I have checkedout this version of the lib in my current project that was already using it and all is fine. Later, implemented new tests using the regex for the dynamic named files/paths and all is fine. 

### Applicable Issues
 Could not run tests locally.
