### PR TITLE
Queue the store method of export class for fromCollection

### DIFF
--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -6,6 +6,7 @@ use Maatwebsite\Excel\Exporter;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Maatwebsite\Excel\Exceptions\NoFilenameGivenException;
 use Maatwebsite\Excel\Exceptions\NoFilePathGivenException;
+use Maatwebsite\Excel\Jobs\QueueExportClass;
 
 trait Exportable
 {
@@ -71,6 +72,10 @@ trait Exportable
 
         if (null === $filePath) {
             throw NoFilePathGivenException::export();
+        }
+
+        if($this instanceof FromCollection) {
+            return QueueExportClass::dispatch($this, func_get_args());
         }
 
         return $this->getExporter()->queue(

--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Concerns;
 
 use Maatwebsite\Excel\Exporter;
-use Maatwebsite\Excel\Jobs\QueueExportClass;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Maatwebsite\Excel\Exceptions\NoFilenameGivenException;
 use Maatwebsite\Excel\Exceptions\NoFilePathGivenException;

--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -74,10 +74,6 @@ trait Exportable
             throw NoFilePathGivenException::export();
         }
 
-        if ($this instanceof FromCollection) {
-            return QueueExportClass::dispatch($this, func_get_args());
-        }
-
         return $this->getExporter()->queue(
             $this,
             $filePath,
@@ -103,7 +99,7 @@ trait Exportable
     /**
      * @return Exporter
      */
-    private function getExporter(): Exporter
+    public function getExporter(): Exporter
     {
         return app(Exporter::class);
     }

--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -3,10 +3,10 @@
 namespace Maatwebsite\Excel\Concerns;
 
 use Maatwebsite\Excel\Exporter;
+use Maatwebsite\Excel\Jobs\QueueExportClass;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Maatwebsite\Excel\Exceptions\NoFilenameGivenException;
 use Maatwebsite\Excel\Exceptions\NoFilePathGivenException;
-use Maatwebsite\Excel\Jobs\QueueExportClass;
 
 trait Exportable
 {
@@ -74,7 +74,7 @@ trait Exportable
             throw NoFilePathGivenException::export();
         }
 
-        if($this instanceof FromCollection) {
+        if ($this instanceof FromCollection) {
             return QueueExportClass::dispatch($this, func_get_args());
         }
 

--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -61,11 +61,12 @@ trait Exportable
      * @param string|null $disk
      * @param string|null $writerType
      * @param mixed       $diskOptions
+     * @param int|null    $tries
      *
      * @throws NoFilePathGivenException
      * @return PendingDispatch
      */
-    public function queue(string $filePath = null, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function queue(string $filePath = null, string $disk = null, string $writerType = null, $diskOptions = [], $tries = null)
     {
         $filePath = $filePath ?? $this->filePath ?? null;
 
@@ -78,7 +79,8 @@ trait Exportable
             $filePath,
             $disk ?? $this->disk ?? null,
             $writerType ?? $this->writerType ?? null,
-            $diskOptions ?? $this->diskOptions ?? []
+            $diskOptions ?? $this->diskOptions ?? [],
+            $tries ?? $this->tries ?? null
         );
     }
 

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -112,7 +112,7 @@ class Excel implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [], $tries = null)
     {
         $writerType = FileTypeDetector::detectStrict($filePath, $writerType);
 
@@ -121,7 +121,8 @@ class Excel implements Exporter, Importer
             $filePath,
             $disk,
             $writerType,
-            $diskOptions
+            $diskOptions,
+            $tries
         );
     }
 

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -4,9 +4,9 @@ namespace Maatwebsite\Excel;
 
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Files\Filesystem;
+use Maatwebsite\Excel\Jobs\QueuedExport;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Maatwebsite\Excel\Jobs\QueueExportClass;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Maatwebsite\Excel\Helpers\FileTypeDetector;
 
@@ -116,7 +116,7 @@ class Excel implements Exporter, Importer
     {
         $writerType = FileTypeDetector::detectStrict($filePath, $writerType);
 
-        return QueueExportClass::dispatch(
+        return QueuedExport::dispatch(
             $export,
             $filePath,
             $disk,

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Files\Filesystem;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Maatwebsite\Excel\Jobs\QueueExportClass;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Maatwebsite\Excel\Helpers\FileTypeDetector;
-use Maatwebsite\Excel\Jobs\QueueExportClass;
 
 class Excel implements Exporter, Importer
 {

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -45,17 +45,6 @@ interface Exporter
     public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [], $tries = null);
 
     /**
-     * @param object      $export
-     * @param string      $filePath
-     * @param string|null $disk
-     * @param string      $writerType
-     * @param mixed       $diskOptions
-     *
-     * @return PendingDispatch
-     */
-    public function storeQueued($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = []);
-
-    /**
      * @param object $export
      * @param string $writerType
      *

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -38,10 +38,11 @@ interface Exporter
      * @param string|null $disk
      * @param string      $writerType
      * @param mixed       $diskOptions
+     * @param int|null    $tries
      *
      * @return PendingDispatch
      */
-    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = []);
+    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [], $tries = null);
 
     /**
      * @param object      $export

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -44,6 +44,17 @@ interface Exporter
     public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = []);
 
     /**
+     * @param object      $export
+     * @param string      $filePath
+     * @param string|null $disk
+     * @param string      $writerType
+     * @param mixed       $diskOptions
+     *
+     * @return PendingDispatch
+     */
+    public function storeQueued($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = []);
+
+    /**
      * @param object $export
      * @param string $writerType
      *

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -68,7 +68,7 @@ class ExcelFake implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [], $tries = null)
     {
         Queue::fake();
 

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -86,6 +86,16 @@ class ExcelFake implements Exporter, Importer
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function storeQueued($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+    {
+        $this->stored[$disk ?? 'default'][$filePath] = $export;
+
+        return true;
+    }
+
+    /**
      * @param object $export
      * @param string $writerType
      *

--- a/src/Helpers/StoreHelper.php
+++ b/src/Helpers/StoreHelper.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Maatwebsite\Excel\Helpers;
+
+use Maatwebsite\Excel\Writer;
+use Maatwebsite\Excel\Files\Disk;
+
+class StoreHelper
+{
+    /**
+     * @param object        $export
+     * @param Writer        $writer
+     * @param Disk          $disk
+     * @param string        $filePath
+     * @param string|null   $writerType
+     *
+     * @throws \Maatwebsite\Excel\Exceptions\NoTypeDetectedException
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @return bool
+     */
+    public static function store($export, Writer $writer, Disk $disk, string $filePath, string $writerType = null)
+    {
+        $writerType = FileTypeDetector::detectStrict($filePath, $writerType);
+
+        $temporaryFile = $writer->export($export, $writerType);
+
+        $exported = $disk->copy($temporaryFile, $filePath);
+        $temporaryFile->delete();
+
+        return $exported;
+    }
+}

--- a/src/Jobs/QueueExportClass.php
+++ b/src/Jobs/QueueExportClass.php
@@ -2,14 +2,12 @@
 
 namespace Maatwebsite\Excel\Jobs;
 
+use Throwable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Maatwebsite\Excel\Concerns\WithEvents;
-use Maatwebsite\Excel\Events\ImportFailed;
-use Throwable;
 
 class QueueExportClass implements ShouldQueue
 {
@@ -34,7 +32,7 @@ class QueueExportClass implements ShouldQueue
     public function __construct($export, $args)
     {
         $this->export = $export;
-        $this->args = $args;
+        $this->args   = $args;
     }
 
     /**

--- a/src/Jobs/QueueExportClass.php
+++ b/src/Jobs/QueueExportClass.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Maatwebsite\Excel\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\ImportFailed;
+use Throwable;
+
+class QueueExportClass implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @var object
+     */
+    public $export;
+
+    /**
+     * @var array
+     */
+    public $args;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param $export
+     * @param $args
+     */
+    public function __construct($export, $args)
+    {
+        $this->export = $export;
+        $this->args = $args;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->export->store(...$this->args);
+    }
+
+    /**
+     * @param Throwable $e
+     */
+    public function failed(Throwable $e)
+    {
+        if (method_exists($this->export, 'failed')) {
+            $this->export->failed($e);
+        }
+    }
+}

--- a/src/Jobs/QueueExportClass.php
+++ b/src/Jobs/QueueExportClass.php
@@ -39,6 +39,11 @@ class QueueExportClass implements ShouldQueue
     public $diskOptions;
 
     /**
+     * @var int
+     */
+    public $tries;
+
+    /**
      * Create a new job instance.
      *
      * @param object $export
@@ -46,14 +51,16 @@ class QueueExportClass implements ShouldQueue
      * @param string|null $disk
      * @param string|null $writerType
      * @param array $diskOptions
+     * @param int|null $tries
      */
-    public function __construct($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function __construct($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [], $tries = null)
     {
         $this->export      = $export;
         $this->filePath    = $filePath;
         $this->disk        = $disk;
         $this->writerType  = $writerType;
         $this->diskOptions = $diskOptions;
+        $this->tries       = $tries;
     }
 
     /**

--- a/src/Jobs/QueueExportClass.php
+++ b/src/Jobs/QueueExportClass.php
@@ -21,18 +21,39 @@ class QueueExportClass implements ShouldQueue
     /**
      * @var array
      */
-    public $args;
+    public $filePath;
+
+    /**
+     * @var string|null
+     */
+    public $disk;
+
+    /**
+     * @var string|null
+     */
+    public $writerType;
+
+    /**
+     * @var array
+     */
+    public $diskOptions;
 
     /**
      * Create a new job instance.
      *
-     * @param $export
-     * @param $args
+     * @param object $export
+     * @param string $filePath
+     * @param string|null $disk
+     * @param string|null $writerType
+     * @param array $diskOptions
      */
-    public function __construct($export, $args)
+    public function __construct($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
     {
-        $this->export = $export;
-        $this->args   = $args;
+        $this->export      = $export;
+        $this->filePath    = $filePath;
+        $this->disk        = $disk;
+        $this->writerType  = $writerType;
+        $this->diskOptions = $diskOptions;
     }
 
     /**
@@ -42,7 +63,13 @@ class QueueExportClass implements ShouldQueue
      */
     public function handle()
     {
-        $this->export->store(...$this->args);
+        $this->export->getExporter()->storeQueued(
+            $this->export,
+            $this->filePath,
+            $this->disk,
+            $this->writerType,
+            $this->diskOptions
+        );
     }
 
     /**

--- a/src/Jobs/QueuedExport.php
+++ b/src/Jobs/QueuedExport.php
@@ -9,7 +9,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 
-class QueueExportClass implements ShouldQueue
+class QueuedExport implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -120,11 +120,10 @@ class FromQueryTest extends TestCase
 
         $export->queue('from-query-with-eager-loads.xlsx');
 
-        // Should be 3 queries:
-        // 1) Count users to create chunked queues
-        // 2) select all users
-        // 3) eager load query for groups
-        $this->assertCount(3, DB::getQueryLog());
+        // Should be 2 queries:
+        // 1) select all users
+        // 2) eager load query for groups
+        $this->assertCount(2, DB::getQueryLog());
         DB::connection()->disableQueryLog();
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-with-eager-loads.xlsx', 'Xlsx');

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -5,11 +5,11 @@ namespace Maatwebsite\Excel\Tests;
 use Throwable;
 use Maatwebsite\Excel\Excel;
 use Illuminate\Support\Facades\Queue;
-use Maatwebsite\Excel\Jobs\QueueExportClass;
-use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
+use Maatwebsite\Excel\Jobs\QueuedExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\ShouldQueueExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedHook;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport as QueuedExportStub;
 use Maatwebsite\Excel\Tests\Data\Stubs\EloquentCollectionWithMappingExport;
 
 class QueuedExportTest extends TestCase
@@ -19,7 +19,7 @@ class QueuedExportTest extends TestCase
      */
     public function can_queue_an_export()
     {
-        $export = new QueuedExport();
+        $export = new QueuedExportStub();
 
         $export->queue('queued-export.xlsx')->chain([
             new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-export.xlsx'),
@@ -31,7 +31,7 @@ class QueuedExportTest extends TestCase
      */
     public function can_queue_an_export_and_store_on_different_disk()
     {
-        $export = new QueuedExport();
+        $export = new QueuedExportStub();
 
         $export->queue('queued-export.xlsx', 'test')->chain([
             new AfterQueueExportJob(__DIR__ . '/Data/Disks/Test/queued-export.xlsx'),
@@ -45,7 +45,7 @@ class QueuedExportTest extends TestCase
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
 
-        $export = new QueuedExport();
+        $export = new QueuedExportStub();
 
         $export->queue('queued-export.xlsx')->chain([
             new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-export.xlsx'),
@@ -113,9 +113,9 @@ class QueuedExportTest extends TestCase
 
         $export->queue('queued-export.xlsx');
 
-        Queue::assertPushed(QueueExportClass::class, 1);
+        Queue::assertPushed(QueuedExport::class, 1);
         // Job should have no maximum attempts per default
-        Queue::assertPushed(QueueExportClass::class, function ($job) {
+        Queue::assertPushed(QueuedExport::class, function ($job) {
             return $job->tries === null;
         });
 
@@ -123,8 +123,8 @@ class QueuedExportTest extends TestCase
         $export->queue('queued-export.xlsx', null, null, null, $tries);
 
         // Job should be pushed twice
-        Queue::assertPushed(QueueExportClass::class, 2);
-        Queue::assertPushed(QueueExportClass::class, function ($job) use ($tries) {
+        Queue::assertPushed(QueuedExport::class, 2);
+        Queue::assertPushed(QueuedExport::class, function ($job) use ($tries) {
             return $job->tries === 3;
         });
     }

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -2,14 +2,8 @@
 
 namespace Maatwebsite\Excel\Tests;
 
-use Maatwebsite\Excel\Jobs\QueueExportClass;
 use Throwable;
 use Maatwebsite\Excel\Excel;
-use Illuminate\Support\Facades\Queue;
-use Illuminate\Queue\Events\JobProcessing;
-use Maatwebsite\Excel\Files\TemporaryFile;
-use Maatwebsite\Excel\Jobs\AppendDataToSheet;
-use Maatwebsite\Excel\Files\RemoteTemporaryFile;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\ShouldQueueExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;


### PR DESCRIPTION
### Requirements

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

See #2278 

Instead of queuing the export data when using the `->queue` method (according to the [documentation](https://docs.laravel-excel.com/3.1/exports/queued.html) for `fromCollection` instances, it queues the `store()` method from the export class itself.

### Why Should This Be Added?

Minimize the job's payload since it's limited in queues like Beanstalkd.

### Benefits

Using the `queued` functionallity for `fromCollection` instances without problems.

### Possible Drawbacks

Using session information like `auth()->user()` isn't possible. You have to pass it to the constructor if necessary. 

Due to code structure, the implicit export queueing works the same way as before. The code would run into a loop since the `store()` method checks if it `ShouldQueue`.

 I couldn't find a good solution yet. Maybe there is some help / ideas. 😉 

### Verification Process

* [x] All tests are in the green
* [x] Made tests with `->queue()` and `ShouldQueue`

### Applicable Issues
