### PR TITLE
Make installable on Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "phpoffice/phpspreadsheet": "^1.6",
     "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
     "opis/closure": "^3.1",
-    "orchestra/testbench": "3.9.x@dev"
+    "orchestra/testbench": "3.9.x@dev|^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
Laravel 6 requires Testbench 4.x, and thus composer fails to install the 3.1.16 tagged copy of this code. Once this PR is in place, please tag this code as 3.1.17 so people can pull it with composer.