### PR TITLE
Added `FromGenerator` support

### DIFF
--- a/src/Concerns/FromGenerator.php
+++ b/src/Concerns/FromGenerator.php
@@ -2,7 +2,12 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
+use Generator;
+
 interface FromGenerator
 {
-    public function generator();
+    /**
+     * @return Generator
+     */
+    public function generator(): Generator;
 }

--- a/src/Concerns/FromGenerator.php
+++ b/src/Concerns/FromGenerator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface FromGenerator
+{
+    public function generator();
+}

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel;
 
 use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromGenerator;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToModel;
 use PhpOffice\PhpSpreadsheet\IOFactory;
@@ -207,6 +208,11 @@ class Sheet
             if ($sheetExport instanceof FromIterator) {
                 $this->fromIterator($sheetExport);
             }
+
+            if ($sheetExport instanceof FromGenerator) {
+                $this->fromGenerator($sheetExport);
+            }
+
         }
 
         $this->close($sheetExport);
@@ -391,6 +397,15 @@ class Sheet
     {
         $this->appendRows($sheetExport->iterator(), $sheetExport);
     }
+
+    /**
+     * @param FromGenerator $sheetExport
+     */
+    public function fromGenerator(FromGenerator $sheetExport)
+    {
+        $this->appendRows($sheetExport->generator(), $sheetExport);
+    }
+
 
     /**
      * @param array       $rows

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -212,7 +212,6 @@ class Sheet
             if ($sheetExport instanceof FromGenerator) {
                 $this->fromGenerator($sheetExport);
             }
-
         }
 
         $this->close($sheetExport);
@@ -405,7 +404,6 @@ class Sheet
     {
         $this->appendRows($sheetExport->generator(), $sheetExport);
     }
-
 
     /**
      * @param array       $rows

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel;
 
 use Illuminate\Support\Collection;
-use Maatwebsite\Excel\Concerns\FromGenerator;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToModel;
 use PhpOffice\PhpSpreadsheet\IOFactory;
@@ -29,6 +28,7 @@ use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\WithDrawings;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Imports\ModelImporter;
+use Maatwebsite\Excel\Concerns\FromGenerator;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 use Maatwebsite\Excel\Concerns\WithMappedCells;

--- a/tests/Concerns/FromGeneratorTest.php
+++ b/tests/Concerns/FromGeneratorTest.php
@@ -4,8 +4,8 @@ namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Generator;
 use Maatwebsite\Excel\Tests\TestCase;
-use Maatwebsite\Excel\Concerns\FromGenerator;
 use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromGenerator;
 
 class FromGeneratorTest extends TestCase
 {

--- a/tests/Concerns/FromGeneratorTest.php
+++ b/tests/Concerns/FromGeneratorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Generator;
+use Maatwebsite\Excel\Tests\TestCase;
+use Maatwebsite\Excel\Concerns\FromGenerator;
+use Maatwebsite\Excel\Concerns\Exportable;
+
+class FromGeneratorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_export_from_generator()
+    {
+        $export = new class implements FromGenerator {
+            use Exportable;
+
+            /**
+             * @return Generator;
+             */
+            public function generator(): Generator
+            {
+                for ($i = 1; $i <= 2; $i++) {
+                    yield ['test', 'test'];
+                }
+            }
+        };
+
+        $response = $export->store('from-generator-store.xlsx');
+
+        $this->assertTrue($response);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-generator-store.xlsx', 'Xlsx');
+
+        $this->assertEquals(iterator_to_array($export->generator()), $contents);
+    }
+}


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change
Added `FromGenerator` support (https://www.php.net/manual/en/language.generators.syntax.php#control-structures.yield)

### Why Should This Be Added?

Useful to export large collections data structure and save memory.

### Benefits

Useful to export large collections data structure and save memory.

### Possible Drawbacks

### Verification Process

### Applicable Issues

