### PR TITLE
Review the BeforeImport Behaviour + buildSheetImports function review.

### DIFF
--- a/src/Events/AfterLoad.php
+++ b/src/Events/AfterLoad.php
@@ -1,0 +1,45 @@
+<?php
+namespace Maatwebsite\Excel\Events;
+use Maatwebsite\Excel\Reader;
+class AfterLoad extends Event
+{
+    // @todo: RRE Review Functionality
+    /**
+     * @var Reader
+     */
+    public $reader;
+    /**
+     * @var object
+     */
+    private $importable;
+    /**
+     * @param Reader $reader
+     * @param object $importable
+     */
+    public function __construct(Reader $reader, $importable)
+    {
+        $this->reader     = $reader;
+        $this->importable = $importable;
+    }
+    /**
+     * @return Reader
+     */
+    public function getReader(): Reader
+    {
+        return $this->reader;
+    }
+    /**
+     * @return object
+     */
+    public function getConcernable()
+    {
+        return $this->importable;
+    }
+    /**
+     * @return mixed
+     */
+    public function getDelegate()
+    {
+        return $this->reader;
+    }
+}

--- a/src/Events/BeforeLoad.php
+++ b/src/Events/BeforeLoad.php
@@ -1,0 +1,45 @@
+<?php
+namespace Maatwebsite\Excel\Events;
+use Maatwebsite\Excel\Reader;
+class BeforeLoad extends Event
+{
+    // @todo: Review Funcitonality
+    /**
+     * @var Reader
+     */
+    public $reader;
+    /**
+     * @var object
+     */
+    private $importable;
+    /**
+     * @param Reader $reader
+     * @param object $importable
+     */
+    public function __construct(Reader $reader, $importable)
+    {
+        $this->reader     = $reader;
+        $this->importable = $importable;
+    }
+    /**
+     * @return Reader
+     */
+    public function getReader(): Reader
+    {
+        return $this->reader;
+    }
+    /**
+     * @return object
+     */
+    public function getConcernable()
+    {
+        return $this->importable;
+    }
+    /**
+     * @return mixed
+     */
+    public function getDelegate()
+    {
+        return $this->reader;
+    }
+}

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -210,14 +210,21 @@ class Reader
      */
     public function loadSpreadsheet($import)
     {
+        // @todo: Review modification at buildSheetImports()
         $this->sheetImports = $this->buildSheetImports($import);
         
         // @todo: review - If the Objective of the Before Import is to be able to Change
-        // the Reader, It should be Before the Read.        
-        $this->beforeImport($import);
+        // the Reader, It should be Before the Read.
+        // @todo: Create Events\BeforeLoad.php
+        // @todo: Define the function beforeLoad()
+        $this->beforeLoad($import);
         
-        // $this->readSpreadsheet();
+        $this->readSpreadsheet();
 
+        // @todo: Create Events\AfterLoad.php
+        // @todo: Define the function afterLoad()
+        $this->afterLoad($import);
+        
         // When no multiple sheets, use the main import object
         // for each loaded sheet in the spreadsheet
         // @todo: If the change in the function $this->buildSheetImports($import); works
@@ -226,12 +233,8 @@ class Reader
             // $this->sheetImports = array_fill(0, $this->spreadsheet->getSheetCount(), $import);
             $this->sheetImports = array_fill(0, sizeof($this->reader->listWorkSheetNames($this->currentFile->getLocalPath())), $import);
         }
-
-        // @todo: review - If the read was needed to be able to run $this->spreadsheet->getSheetCount()
-        // With the change above is solved.
-        $this->readSpreadsheet();
         
-//        $this->beforeImport($import);
+        $this->beforeImport($import);
     }
 
     public function readSpreadsheet()
@@ -259,6 +262,25 @@ class Reader
         $this->garbageCollect();
     }
 
+    /**
+     * @todo: Create Events\BeforeLoad.php
+     * @param  object  $import
+     */
+    public function beforeLoad($import)
+    {
+        $this->raise(new BeforeLoad($this, $import));
+    }
+
+    /**
+     * @todo: Create Events\AfterLoad.php
+     * @param  object  $import
+     */
+    public function afterLoad($import)
+    {
+        $this->raise(new AfterLoad($this, $import));
+    }
+    
+    
     /**
      * @return IReader
      */

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -211,16 +211,27 @@ class Reader
     public function loadSpreadsheet($import)
     {
         $this->sheetImports = $this->buildSheetImports($import);
-
-        $this->readSpreadsheet();
+        
+        // @todo: review - If the Objective of the Before Import is to be able to Change
+        // the Reader, It should be Before the Read.        
+        $this->beforeImport($import);
+        
+        // $this->readSpreadsheet();
 
         // When no multiple sheets, use the main import object
         // for each loaded sheet in the spreadsheet
+        // @todo: If the change in the function $this->buildSheetImports($import); works
+        //      this section of code is redundant and can be removed.
         if (!$import instanceof WithMultipleSheets) {
-            $this->sheetImports = array_fill(0, $this->spreadsheet->getSheetCount(), $import);
+            // $this->sheetImports = array_fill(0, $this->spreadsheet->getSheetCount(), $import);
+            $this->sheetImports = array_fill(0, sizeof($this->reader->listWorkSheetNames($this->currentFile->getLocalPath())), $import);
         }
 
-        $this->beforeImport($import);
+        // @todo: review - If the read was needed to be able to run $this->spreadsheet->getSheetCount()
+        // With the change above is solved.
+        $this->readSpreadsheet();
+        
+//        $this->beforeImport($import);
     }
 
     public function readSpreadsheet()
@@ -361,6 +372,10 @@ class Reader
             ) {
                 $this->reader->setLoadSheetsOnly(array_keys($sheetImports));
             }
+        } else {
+            // Replicate the functionality implemented in public function loadSpreadsheet($import)
+            // @todo: If this works, The code in loadSpreadsheet to achieve this is redundant.
+            $sheetImports = array_fill(0, sizeof($this->reader->listWorkSheetNames($this->currentFile->getLocalPath())), $import);
         }
 
         return $sheetImports;


### PR DESCRIPTION
If the objective of the "BeforeImport" is different than to have access to the object, BEFORE the process which loads of the data, please advice how to implement this change.

Considerations:
If the objective is to be able to access the Reader before the actual load, this change could affect multiple installations and a NEW EVENT NEEDS to be created. If the programmers are using the BeforeImport with the Data Loaded by $this->readSpreadsheet(); this change WILL break their code.

In the function analysis, the recommendation is to change the response from  $this->sheetImports = $this->buildSheetImports($import); which buildSheetImports($import) should return the required values in the array.

The function "private function buildSheetImports($import): array" , Returns Always an EMPTY array if an instance of "WithMultipleSheets"

### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x ] Checked the codebase to ensure that your feature doesn't already exist.
* [ x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, 
the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have 
worked with the code here recently, so please walk us through the concepts.

-->

Be able to control the Read Object Before the Load.
Actually the BeforeImport is executed AFTER the load of the data.

### Why Should This Be Added?

<!-- Explain why this functionality should be added in Laravel-Excel -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts (e.g. breaking changes) of the code change? -->

Considerations:
If the objective is to be able to access the Reader before the actual load, this change could affect multiple installations and a NEW EVENT NEEDS to be created. If the programmers are using the BeforeImport with the Data Loaded by $this->readSpreadsheet(); this change WILL break their code.


### Verification Process

At the moment I don't know what is the expected designed functionality of the "BeforeImport".

Maybe my conception is different in how to use the BeforeImport.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

-->

### Applicable Issues

<!-- Enter any applicable Issues here -->
