### PR TITLE
Limit WithProgressBar output to one per batch

### DIFF
--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -32,18 +32,21 @@ class ModelImporter
      */
     public function import(Worksheet $worksheet, ToModel $import, int $startRow = 1)
     {
-        $headingRow = HeadingRowExtractor::extract($worksheet, $import);
-        $batchSize  = $import instanceof WithBatchInserts ? $import->batchSize() : 1;
-        $endRow     = EndRowFinder::find($import, $startRow);
+        $headingRow       = HeadingRowExtractor::extract($worksheet, $import);
+        $batchSize        = $import instanceof WithBatchInserts ? $import->batchSize() : 1;
+        $endRow           = EndRowFinder::find($import, $startRow);
+        $progessBar       = $import instanceof WithProgressBar;
+        $withMapping      = $import instanceof WithMapping;
+        $withCalcFormulas = $import instanceof WithCalculatedFormulas;
 
         $i = 0;
         foreach ($worksheet->getRowIterator($startRow, $endRow) as $spreadSheetRow) {
             $i++;
 
             $row      = new Row($spreadSheetRow, $headingRow);
-            $rowArray = $row->toArray(null, $import instanceof WithCalculatedFormulas);
+            $rowArray = $row->toArray(null, $withCalcFormulas);
 
-            if ($import instanceof WithMapping) {
+            if ($withMapping) {
                 $rowArray = $import->map($rowArray);
             }
 
@@ -56,10 +59,10 @@ class ModelImporter
             if (($i % $batchSize) === 0) {
                 $this->manager->flush($import, $batchSize > 1);
                 $i = 0;
-            }
 
-            if ($import instanceof WithProgressBar) {
-                $import->getConsoleOutput()->progressAdvance();
+                if ($progessBar) {
+                    $import->getConsoleOutput()->progressAdvance($batchSize);
+                }
             }
         }
 


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.

    > **Reason:** The [current docs](https://docs.laravel-excel.com/3.1/imports/progress-bar.html) make no mention of how frequently the bar updates therefore I did not see a need to insert the fact that it would now do it only once per batch
* [ ] Added tests to ensure against regression.

    > **Reason:** Not entirely sure how I'd write tests for this

### Description of the Change

This PR is a realization of my proposal that aims to limit the number of console writes performed during an import that makes use of the progress bar.

### Why Should This Be Added?

Sending less output to the console is generally a good idea, and during a batch insert there's little to no reason to inform the user about each individual loop cycle since:

 * it ultimately makes no difference to know if we're on loop iteration 7,534 or 7,535 out of 20,000 since the most likely points of failure are when the data is actually getting inserted
 * the batch size is configurable to the developer's liking; if the error message that follows a failing insert has too much record data to narrow any potential issue down the batch size can be decreased
 * now the user won't be erroneously shown that any `n % $batchSize !== 0` inserts were "successful" by only incrementing the progress bar when an insert succeeded

### Benefits

Less console writes that should hopefully result in faster imports on low-end machines and over slower SSH connections and slightly more accurate progress reporting.

### Possible Drawbacks

Users will miss out on roughly `$records - ($records * $batchSize)` (±1) progress bar updates when they are using `WithProgressBar` and `WithBatchInserts` together. This might lead to confusion if someone unfamiliar with this behavior thinks the script froze while importing with an absurd batch size that does not update the progress bar frequently enough.

### Verification Process

In my personal testing in an Ubuntu 19.04 VM running the command locally before and after this change using an `implements ToModel, WithHeadingRow, WithBatchInserts, WithProgressBar` worksheet class, a batch size of 2000 and a spreadsheet of 14400 rows the performance gain was an average of 4731ms on the overall time from when the library started reading the file to the import finishing over 4 runs for both before and after. This however was an ideal case of the script being run locally (on a relatively powerful machine) from a local terminal and this could potentially increase on slower systems or when running the commands remotely.

### Applicable Issues

#2408 