### PR TITLE
Timeout and number of tries for the chunked import jobs

### DIFF
--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -60,7 +60,7 @@ class ChunkReader
         $jobs->push(new AfterImportJob($import, $reader));
 
         if ($import instanceof ShouldQueue) {
-            return QueueImport::withChain($jobs->toArray())->dispatch();
+            return QueueImport::withChain($jobs->toArray())->dispatch($import);
         }
 
         $jobs->each(function ($job) {

--- a/src/Jobs/QueueImport.php
+++ b/src/Jobs/QueueImport.php
@@ -9,6 +9,27 @@ class QueueImport implements ShouldQueue
 {
     use ExtendedQueueable, Dispatchable;
 
+    /**
+     * @var int
+     */
+    public $tries;
+
+    /**
+     * @var int
+     */
+    public $timeout;
+
+    /**
+     * @param ShouldQueue $import
+     */
+    public function __construct(ShouldQueue $import = null)
+    {
+        if ($import) {
+            $this->timeout = $import->timeout ?? null;
+            $this->tries = $import->tries ?? null;
+        }
+    }
+
     public function handle()
     {
         //

--- a/src/Jobs/QueueImport.php
+++ b/src/Jobs/QueueImport.php
@@ -26,7 +26,7 @@ class QueueImport implements ShouldQueue
     {
         if ($import) {
             $this->timeout = $import->timeout ?? null;
-            $this->tries = $import->tries ?? null;
+            $this->tries   = $import->tries ?? null;
         }
     }
 

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -63,6 +63,11 @@ class ReadChunk implements ShouldQueue
     public $timeout;
 
     /**
+     * @var int
+     */
+    public $tries;
+
+    /**
      * @param  WithChunkReading  $import
      * @param  IReader  $reader
      * @param  TemporaryFile  $temporaryFile
@@ -81,6 +86,7 @@ class ReadChunk implements ShouldQueue
         $this->startRow      = $startRow;
         $this->chunkSize     = $chunkSize;
         $this->timeout       = $import->timeout ?? null;
+        $this->tries         = $import->tries ?? null;
     }
 
     /**

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -58,6 +58,11 @@ class ReadChunk implements ShouldQueue
     private $chunkSize;
 
     /**
+     * @var int
+     */
+    public $timeout;
+
+    /**
      * @param  WithChunkReading  $import
      * @param  IReader  $reader
      * @param  TemporaryFile  $temporaryFile
@@ -75,6 +80,7 @@ class ReadChunk implements ShouldQueue
         $this->sheetImport   = $sheetImport;
         $this->startRow      = $startRow;
         $this->chunkSize     = $chunkSize;
+        $this->timeout       = $import->timeout ?? null;
     }
 
     /**

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -23,6 +23,16 @@ class ReadChunk implements ShouldQueue
     use Queueable, HasEventBus;
 
     /**
+     * @var int
+     */
+    public $timeout;
+
+    /**
+     * @var int
+     */
+    public $tries;
+
+    /**
      * @var WithChunkReading
      */
     private $import;
@@ -56,16 +66,6 @@ class ReadChunk implements ShouldQueue
      * @var int
      */
     private $chunkSize;
-
-    /**
-     * @var int
-     */
-    public $timeout;
-
-    /**
-     * @var int
-     */
-    public $tries;
 
     /**
      * @param  WithChunkReading  $import


### PR DESCRIPTION
### Requirements
Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.

Not applicable:
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

Timeout and tries values for the chained queued import jobs could be managed through respective properties of the import class.


### Why Should This Be Added?
 
Queued import job chunks are created with the following settings:
- timeout = null
- tries = null

Laravel uses default timeout setting of 60 seconds that might not be enough per chunk in some cases.

This fix allows to change timeout and number of tries values through respective properties of the import class.

### Benefits

Timeout and tries params could be set through the App\Imports class

### Possible Drawbacks

Not known

### Verification Process

Create queued chunked import.
Check timeout and tries params by analysing 'payload' field in the jobs table.

That fields should correspond values set in the import class or will be null if no values are set.

### Applicable Issues

Not known
