### PR TITLE
Fix for PHP7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "maatwebsite/excel",
+  "name": "ideea/excel",
   "description": "Supercharged Excel exports and imports in Laravel",
   "license": "MIT",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "ext-json": "*",
     "php": "^7.0",
     "phpoffice/phpspreadsheet": "^1.6",
-    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
+    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.*",
     "opis/closure": "^3.1"
   },
   "require-dev": {


### PR DESCRIPTION
After update to PHP 7.4 we got following error:  Trying to access array offset on value of type int

To fix it, I suggest do following update:

In file   DefaultValueBinder.php  string: 

} elseif ($pValue{0} === '=' && strlen($pValue) > 1) {

replace to

} elseif (is_string($pValue) && $pValue[0] === '=' && strlen($pValue) > 1) {
