### PR TITLE
Add fix for on each row and with validation

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -268,11 +268,13 @@ class Sheet
 
                     try {
                         app(RowValidator::class)->validate($toValidate, $import);
+                        $import->onRow($sheetRow);
                     } catch (RowSkippedException $e) {
                     }
                 }
-
-                $import->onRow($sheetRow);
+                else {
+                    $import->onRow($sheetRow);
+                }
 
                 if ($import instanceof WithProgressBar) {
                     $import->getConsoleOutput()->progressAdvance();

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -271,8 +271,7 @@ class Sheet
                         $import->onRow($sheetRow);
                     } catch (RowSkippedException $e) {
                     }
-                }
-                else {
+                } else {
                     $import->onRow($sheetRow);
                 }
 

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -221,7 +221,7 @@ class SkipsOnFailureTest extends TestCase
         ]);
     }
 
-        /**
+    /**
      * @test
      */
     public function can_validate_using_oneachrow_and_skipsonfailure()

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -5,11 +5,13 @@ namespace Maatwebsite\Excel\Tests\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rule;
 use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\SkipsFailures;
 use Maatwebsite\Excel\Concerns\SkipsOnFailure;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithValidation;
+use Maatwebsite\Excel\Row;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\TestCase;
 use Maatwebsite\Excel\Validators\Failure;
@@ -207,6 +209,57 @@ class SkipsOnFailureTest extends TestCase
         $this->assertEquals(2, $failure->row());
         $this->assertEquals('1', $failure->attribute());
         $this->assertEquals(['The selected 1 is invalid.'], $failure->errors());
+
+        // Shouldn't have rollbacked other imported rows.
+        $this->assertDatabaseHas('users', [
+            'email' => 'patrick@maatwebsite.nl',
+        ]);
+
+        // Should have skipped inserting
+        $this->assertDatabaseMissing('users', [
+            'email' => 'taylor@laravel.com',
+        ]);
+    }
+
+        /**
+     * @test
+     */
+    public function can_validate_using_oneachrow_and_skipsonfailure()
+    {
+        $import = new class implements OnEachRow, WithValidation, SkipsOnFailure {
+            use Importable, SkipsFailures;
+
+            /**
+             * @param Row $row
+             *
+             * @return Model|null
+             */
+            public function onRow(Row $row)
+            {
+                $row = $row->toArray();
+
+                return User::create([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @return array
+             */
+            public function rules(): array
+            {
+                return [
+                    '1' => Rule::in(['patrick@maatwebsite.nl']),
+                ];
+            }
+        };
+        $this->assertEmpty(User::all());
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(1, $import->failures());
 
         // Shouldn't have rollbacked other imported rows.
         $this->assertDatabaseHas('users', [


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation. (Not Applicable)
* [x] Added tests to ensure against regression.

### Description of the Change

The following merged PR https://github.com/Maatwebsite/Laravel-Excel/pull/2371 has a bug where SkipsOnFailure concern isn't respected when used in tandem with OnEachRow and WithValidation concerns. This PR removes this bug.

### Why Should This Be Added?

Currently even if a row fails validation it will still be inserted into the database.

### Benefits

Removes the incidence of invalid rows being inserted into the database.

### Possible Drawbacks

None.

### Verification Process

I added a test to Laravel-Excel/tests/Concerns/SkipsOnFailureTest::class@can_validate_using_oneachrow_and_skipsonfailure that was failing before change was made, and passes after change is made.

### Applicable Issues

Let me know if any further changes are needed 👍🏻
