### PR TITLE
[WIP] Use cursor() to reduce memory footprint

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -387,8 +387,8 @@ class Sheet
      */
     public function fromQuery(FromQuery $sheetExport, Worksheet $worksheet)
     {
-        $sheetExport->query()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport, $worksheet) {
-            $this->appendRows($chunk->cursor(), $sheetExport);
+        $sheetExport->query()->cursor()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport, $worksheet) {
+            $this->appendRows($chunk, $sheetExport);
         });
     }
 

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -387,9 +387,11 @@ class Sheet
      */
     public function fromQuery(FromQuery $sheetExport, Worksheet $worksheet)
     {
-        $sheetExport->query()->cursor()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport, $worksheet) {
-            $this->appendRows($chunk, $sheetExport);
-        });
+        $this->appendRows($sheetExport->query()->cursor(), $sheetExport);
+
+        // $sheetExport->query()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport, $worksheet) {
+        //     $this->appendRows($chunk, $sheetExport);
+        // });
     }
 
     /**

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -388,7 +388,7 @@ class Sheet
     public function fromQuery(FromQuery $sheetExport, Worksheet $worksheet)
     {
         $sheetExport->query()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport, $worksheet) {
-            $this->appendRows($chunk, $sheetExport);
+            $this->appendRows($chunk->cursor(), $sheetExport);
         });
     }
 


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

This PR is a draft of my proposal made in #2590. The idea is to update the `FromQuery`-concern implementation to always use `cursor()` / [LazyCollections](https://laravel.com/docs/7.x/collections#lazy-collections).

### Why Should This Be Added?

- Automatically improves memory footprint of all exports

### Benefits

- Applications will no longer run into memory limits, as the Export will only keep a small number of records in memory.

### Possible Drawbacks

- Not backwards compatible with Laravel 5.*

### Verification Process

> TBD

### Applicable Issues

- Large exports which include multiple thousands of rows.
