### PR TITLE
Change LocalTemporaryFile readStream method to fix issues with s3

### DIFF
--- a/src/Files/LocalTemporaryFile.php
+++ b/src/Files/LocalTemporaryFile.php
@@ -48,7 +48,7 @@ class LocalTemporaryFile extends TemporaryFile
      */
     public function readStream()
     {
-        return fopen($this->getLocalPath(), 'rb+');
+        return fopen($this->getLocalPath(), 'rb');
     }
 
     /**

--- a/src/Files/LocalTemporaryFile.php
+++ b/src/Files/LocalTemporaryFile.php
@@ -48,7 +48,7 @@ class LocalTemporaryFile extends TemporaryFile
      */
     public function readStream()
     {
-        return fopen($this->getLocalPath(), 'rb');
+        return fopen($this->getLocalPath(), 'r+b');
     }
 
     /**


### PR DESCRIPTION
### Requirements

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

See issue: #2156 

Realocate the "+" for the LocalTemporaryFile class when using readStream method. On my use case, the "+" used after "r" and before "b" solves the problem. The character order with "b" as the last character is in conformity with php documentation for `fopen()`.

### Why Should This Be Added?

From my testing it seemed to fix the bug/issue with storing to s3.

### Benefits

If anyone else encounters this issue it would hopefully resolve it for them as well.

### Possible Drawbacks

Due to this seemingly being isolated to my application/environment it's possible it will break something for someone else.

### Verification Process

I tested the following changes on the same file multiple times, with the same data, different data and the change always worked.

```php
// original
fopen($this->getLocalPath(), 'rb+');
// Changed to (fixes the issue)
fopen($this->getLocalPath(), 'r+b');
```

### Applicable Issues

#2156 