### PR TITLE
Fix "validation file format by extension recognition" for remote-disks

### DIFF
--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -34,7 +34,7 @@ class TemporaryFileFactory
     public function make(string $fileExtension = null): TemporaryFile
     {
         if (null !== $this->temporaryDisk) {
-            return $this->makeRemote();
+            return $this->makeRemote($fileExtension);
         }
 
         return $this->makeLocal(null, $fileExtension);
@@ -59,11 +59,13 @@ class TemporaryFileFactory
     }
 
     /**
+     * @param string|null $fileExtension
+     *
      * @return RemoteTemporaryFile
      */
-    private function makeRemote(): RemoteTemporaryFile
+    private function makeRemote(string $fileExtension = null): RemoteTemporaryFile
     {
-        $filename = $this->generateFilename();
+        $filename = $this->generateFilename($fileExtension);
 
         return new RemoteTemporaryFile(
             $this->temporaryDisk,

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -106,10 +106,7 @@ class QueuedImportTest extends TestCase
                 $this->assertStringContains('.xlsx', $tempFile->getLocalPath());
             }
         });
-
-        $chain = (new QueuedImport())->queue('import-batches.xlsx');
-
-        $this->assertInstanceOf(PendingDispatch::class, $chain);
+        (new QueuedImport())->queue('import-batches.xlsx');
     }
 
     /**

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -94,6 +94,27 @@ class QueuedImportTest extends TestCase
     /**
      * @test
      */
+    public function can_keep_extension_for_temp_file_on_remote_disk()
+    {
+        config()->set('excel.temporary_files.remote_disk', 'test');
+
+        Queue::before(function (JobProcessing $event) {
+            if ($event->job->resolveName() === ReadChunk::class) {
+                /** @var TemporaryFile $tempFile */
+                $tempFile = $this->inspectJobProperty($event->job, 'temporaryFile');
+
+                $this->assertStringContains('.xlsx', $tempFile->getLocalPath());
+            }
+        });
+
+        $chain = (new QueuedImport())->queue('import-batches.xlsx');
+
+        $this->assertInstanceOf(PendingDispatch::class, $chain);
+    }
+
+    /**
+     * @test
+     */
     public function can_queue_import_with_remote_temp_disk_and_prefix()
     {
         config()->set('excel.temporary_files.remote_disk', 'test');


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

Fixes #2617.

This change keeps the file-extension for temp-files on remote disks the same way it does for lokal disks. 
This helps reading the file correctly as described in this issue (#2107).

### Why Should This Be Added?

With the PR #2224 the behavior is quite different on local and remote disks.

This PR aims at having the same behavior for local and remote disks.

### Benefits

Less Problems reading files from remote.

### Possible Drawbacks

none

### Verification Process

New test case checking for the file extension.

### Applicable Issues

#2617
