### PR TITLE
Fix facade phpdoc

### DIFF
--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -20,9 +20,9 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
  * @method static void matchByRegex()
  * @method static void doNotMatchByRegex()
  * @method static void assertDownloaded(string $fileName, callable $callback = null)
- * @method static void assertStored(string $filePath, string $disk = null, callable $callback = null)
- * @method static void assertQueued(string $filePath, string $disk = null, callable $callback = null)
- * @method static void assertImported(string $filePath, string $disk = null, callable $callback = null)
+ * @method static void assertStored(string $filePath, string|callable $disk = null, callable $callback = null)
+ * @method static void assertQueued(string $filePath, string|callable $disk = null, callable $callback = null)
+ * @method static void assertImported(string $filePath, string|callable $disk = null, callable $callback = null)
  */
 class Excel extends Facade
 {


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

Corrects the PHPDoc of the `assertQueued`, `assertStored` and `assertImported` methods of the `Excel` facade.
<!--

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, 
the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have 
worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

This allows static analysis tools (like Phan) to properly analyze calls to these methods. Right now, Phan would complain if you supply a Closure as a second argument to one of these methods.

