### PR TITLE
Added RemembersRowNumber Trait

### DIFF
--- a/src/Concerns/RemembersRowNumber.php
+++ b/src/Concerns/RemembersRowNumber.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Maatwebsite\Excel\Concerns;
+
+use InvalidArgumentException;
+
+trait RemembersRowNumber
+{
+    /**
+     * @var int|null
+     */
+    protected $rowNumber;
+
+    /**
+     * @param int $rowNumber
+     */
+    public function setRowNumber(int $rowNumber)
+    {
+        $this->rowNumber = $rowNumber;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getRowNumber()
+    {
+        return $this->rowNumber;
+    }
+}

--- a/src/Concerns/RemembersRowNumber.php
+++ b/src/Concerns/RemembersRowNumber.php
@@ -2,10 +2,23 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
-interface RemembersRowNumber
+trait RemembersRowNumber
 {
+    protected $rowNumber;
+
     /**
      * @param int $rowNumber
      */
-    public function setRowNumber(int $rowNumber);
+    public function rememberRowNumber(int $rowNumber)
+    {
+        $this->rowNumber = $rowNumber;
+    }
+
+    /**
+     *
+     */
+    public function getRowNumber()
+    {
+        return $this->rowNumber;
+    }
 }

--- a/src/Concerns/RemembersRowNumber.php
+++ b/src/Concerns/RemembersRowNumber.php
@@ -2,8 +2,6 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
-use InvalidArgumentException;
-
 trait RemembersRowNumber
 {
     /**

--- a/src/Concerns/RemembersRowNumber.php
+++ b/src/Concerns/RemembersRowNumber.php
@@ -4,6 +4,9 @@ namespace Maatwebsite\Excel\Concerns;
 
 trait RemembersRowNumber
 {
+    /**
+     * @var int
+     */
     protected $rowNumber;
 
     /**
@@ -15,7 +18,7 @@ trait RemembersRowNumber
     }
 
     /**
-     *
+     * @return int|null
      */
     public function getRowNumber()
     {

--- a/src/Concerns/RemembersRowNumber.php
+++ b/src/Concerns/RemembersRowNumber.php
@@ -2,26 +2,10 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
-trait RemembersRowNumber
+interface RemembersRowNumber
 {
-    /**
-     * @var int|null
-     */
-    protected $rowNumber;
-
     /**
      * @param int $rowNumber
      */
-    public function setRowNumber(int $rowNumber)
-    {
-        $this->rowNumber = $rowNumber;
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getRowNumber()
-    {
-        return $this->rowNumber;
-    }
+    public function setRowNumber(int $rowNumber);
 }

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Imports;
 
-use Maatwebsite\Excel\Concerns\RemembersRowNumber;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
@@ -44,7 +43,7 @@ class ModelImporter
         $withMapping      = $import instanceof WithMapping;
         $withCalcFormulas = $import instanceof WithCalculatedFormulas;
 
-        $this->manager->setRemembersRowNumber($import instanceof RemembersRowNumber);
+        $this->manager->setRemembersRowNumber(method_exists($import, 'rememberRowNumber'));
 
         $i = 0;
         foreach ($worksheet->getRowIterator($startRow, $endRow) as $spreadSheetRow) {

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -42,6 +42,7 @@ class ModelImporter
         $progessBar       = $import instanceof WithProgressBar;
         $withMapping      = $import instanceof WithMapping;
         $withCalcFormulas = $import instanceof WithCalculatedFormulas;
+        $rememberRow      = method_exists($import, 'setRowNumber');
 
         $i = 0;
         foreach ($worksheet->getRowIterator($startRow, $endRow) as $spreadSheetRow) {
@@ -49,6 +50,10 @@ class ModelImporter
 
             $row      = new Row($spreadSheetRow, $headingRow);
             $rowArray = $row->toArray(null, $withCalcFormulas);
+
+            if ($rememberRow){
+                $import->setRowNumber($row->getIndex());
+            }
 
             if ($withMapping) {
                 $rowArray = $import->map($rowArray);

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -42,7 +42,6 @@ class ModelImporter
         $progessBar       = $import instanceof WithProgressBar;
         $withMapping      = $import instanceof WithMapping;
         $withCalcFormulas = $import instanceof WithCalculatedFormulas;
-        $rememberRow      = method_exists($import, 'setRowNumber');
 
         $i = 0;
         foreach ($worksheet->getRowIterator($startRow, $endRow) as $spreadSheetRow) {
@@ -50,10 +49,6 @@ class ModelImporter
 
             $row      = new Row($spreadSheetRow, $headingRow);
             $rowArray = $row->toArray(null, $withCalcFormulas);
-
-            if ($rememberRow) {
-                $import->setRowNumber($row->getIndex());
-            }
 
             if ($withMapping) {
                 $rowArray = $import->map($rowArray);

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Imports;
 
+use Maatwebsite\Excel\Concerns\RemembersRowNumber;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
@@ -42,6 +43,8 @@ class ModelImporter
         $progessBar       = $import instanceof WithProgressBar;
         $withMapping      = $import instanceof WithMapping;
         $withCalcFormulas = $import instanceof WithCalculatedFormulas;
+
+        $this->manager->setRemembersRowNumber($import instanceof RemembersRowNumber);
 
         $i = 0;
         foreach ($worksheet->getRowIterator($startRow, $endRow) as $spreadSheetRow) {

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -51,7 +51,7 @@ class ModelImporter
             $row      = new Row($spreadSheetRow, $headingRow);
             $rowArray = $row->toArray(null, $withCalcFormulas);
 
-            if ($rememberRow){
+            if ($rememberRow) {
                 $import->setRowNumber($row->getIndex());
             }
 

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -84,7 +84,7 @@ class ModelManager
     public function toModels(ToModel $import, array $attributes, $rowNumber = null): Collection
     {
         if ($this->remembersRowNumber) {
-            $import->setRowNumber($rowNumber);
+            $import->rememberRowNumber($rowNumber);
         }
 
         $model = $import->model($attributes);

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -23,6 +23,10 @@ class ModelManager
      * @var RowValidator
      */
     private $validator;
+    /**
+     * @var bool
+     */
+    private $remembersRowNumber = false;
 
     /**
      * @param RowValidator $validator
@@ -39,6 +43,14 @@ class ModelManager
     public function add(int $row, array $attributes)
     {
         $this->rows[$row] = $attributes;
+    }
+
+    /**
+     * @param bool $remembersRowNumber
+     */
+    public function setRemembersRowNumber(bool $remembersRowNumber)
+    {
+        $this->remembersRowNumber = $remembersRowNumber;
     }
 
     /**
@@ -71,7 +83,7 @@ class ModelManager
      */
     public function toModels(ToModel $import, array $attributes, $rowNumber = null): Collection
     {
-        if (method_exists($import, 'setRowNumber')) {
+        if ($this->remembersRowNumber) {
             $import->setRowNumber($rowNumber);
         }
 

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\RemembersChunkOffset;
+use Maatwebsite\Excel\Concerns\RemembersRowNumber;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Maatwebsite\Excel\Tests\TestCase;
+
+class RemembersRowNumberTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_set_and_get_row_number()
+    {
+        $import = new class {
+            use Importable;
+            use RemembersRowNumber;
+        };
+
+        $import->setRowNumber(50);
+
+        $this->assertEquals(50, $import->getRowNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function can_access_row_number_on_import_to_model()
+    {
+        $import = new class implements ToModel {
+            use Importable;
+            use RemembersRowNumber;
+
+            public $rowNumbers = [];
+
+            public function model(array $row)
+            {
+                $this->rowNumbers[] = $this->getRowNumber();
+            }
+        };
+
+        $import->import('import-batches.xlsx');
+
+        $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
+    }
+
+    /**
+     * @test
+     */
+    public function can_access_row_number_on_import_to_array_in_chunks()
+    {
+        $import = new class implements ToModel, WithChunkReading {
+            use Importable;
+            use RemembersRowNumber;
+
+            public $rowNumbers = [];
+
+            public function chunkSize(): int
+            {
+                return 50;
+            }
+
+            public function model(array $row)
+            {
+                $this->rowNumbers[] = $this->getRowNumber();
+            }
+        };
+
+        $import->import('import-batches.xlsx');
+
+        $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
+    }
+
+}

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -16,14 +16,20 @@ class RemembersRowNumberTest extends TestCase
      */
     public function can_set_and_get_row_number()
     {
-        $import = new class {
+        $import = new class implements RemembersRowNumber {
             use Importable;
-            use RemembersRowNumber;
+
+            public $rowNumber;
+
+            public function setRowNumber(int $rowNumber)
+            {
+                $this->rowNumber = $rowNumber;
+            }
         };
 
         $import->setRowNumber(50);
 
-        $this->assertEquals(50, $import->getRowNumber());
+        $this->assertEquals(50, $import->rowNumber);
     }
 
     /**
@@ -31,15 +37,20 @@ class RemembersRowNumberTest extends TestCase
      */
     public function can_access_row_number_on_import_to_model()
     {
-        $import = new class implements ToModel {
+        $import = new class implements ToModel, RemembersRowNumber {
             use Importable;
-            use RemembersRowNumber;
 
+            private $rowNumber;
             public $rowNumbers = [];
 
             public function model(array $row)
             {
-                $this->rowNumbers[] = $this->getRowNumber();
+                $this->rowNumbers[] = $this->rowNumber;
+            }
+
+            public function setRowNumber(int $rowNumber)
+            {
+                $this->rowNumber = $rowNumber;
             }
         };
 
@@ -53,10 +64,10 @@ class RemembersRowNumberTest extends TestCase
      */
     public function can_access_row_number_on_import_to_array_in_chunks()
     {
-        $import = new class implements ToModel, WithChunkReading {
+        $import = new class implements ToModel, WithChunkReading, RemembersRowNumber {
             use Importable;
-            use RemembersRowNumber;
 
+            private $rowNumber;
             public $rowNumbers = [];
 
             public function chunkSize(): int
@@ -66,7 +77,12 @@ class RemembersRowNumberTest extends TestCase
 
             public function model(array $row)
             {
-                $this->rowNumbers[] = $this->getRowNumber();
+                $this->rowNumbers[] = $this->rowNumber;
+            }
+
+            public function setRowNumber(int $rowNumber)
+            {
+                $this->rowNumber = $rowNumber;
             }
         };
 
@@ -80,10 +96,10 @@ class RemembersRowNumberTest extends TestCase
      */
     public function can_access_row_number_on_import_to_array_in_chunks_with_batch_inserts()
     {
-        $import = new class implements ToModel, WithChunkReading, WithBatchInserts {
+        $import = new class implements ToModel, WithChunkReading, WithBatchInserts, RemembersRowNumber {
             use Importable;
-            use RemembersRowNumber;
 
+            private $rowNumber;
             public $rowNumbers = [];
 
             public function chunkSize(): int
@@ -93,12 +109,17 @@ class RemembersRowNumberTest extends TestCase
 
             public function model(array $row)
             {
-                $this->rowNumbers[] = $this->getRowNumber();
+                $this->rowNumbers[] = $this->rowNumber;
             }
 
             public function batchSize(): int
             {
                 return 50;
+            }
+
+            public function setRowNumber(int $rowNumber)
+            {
+                $this->rowNumber = $rowNumber;
             }
         };
 

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -41,7 +41,6 @@ class RemembersRowNumberTest extends TestCase
             {
                 $this->rowNumbers[] = $this->getRowNumber();
             }
-
         };
 
         $import->import('import-batches.xlsx');

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -16,20 +16,14 @@ class RemembersRowNumberTest extends TestCase
      */
     public function can_set_and_get_row_number()
     {
-        $import = new class implements RemembersRowNumber {
+        $import = new class {
             use Importable;
-
-            public $rowNumber;
-
-            public function setRowNumber(int $rowNumber)
-            {
-                $this->rowNumber = $rowNumber;
-            }
+            use RemembersRowNumber;
         };
 
-        $import->setRowNumber(50);
+        $import->rememberRowNumber(50);
 
-        $this->assertEquals(50, $import->rowNumber);
+        $this->assertEquals(50, $import->getRowNumber());
     }
 
     /**
@@ -37,21 +31,17 @@ class RemembersRowNumberTest extends TestCase
      */
     public function can_access_row_number_on_import_to_model()
     {
-        $import = new class implements ToModel, RemembersRowNumber {
+        $import = new class implements ToModel {
             use Importable;
+            use RemembersRowNumber;
 
-            private $rowNumber;
             public $rowNumbers = [];
 
             public function model(array $row)
             {
-                $this->rowNumbers[] = $this->rowNumber;
+                $this->rowNumbers[] = $this->getRowNumber();
             }
 
-            public function setRowNumber(int $rowNumber)
-            {
-                $this->rowNumber = $rowNumber;
-            }
         };
 
         $import->import('import-batches.xlsx');
@@ -64,10 +54,10 @@ class RemembersRowNumberTest extends TestCase
      */
     public function can_access_row_number_on_import_to_array_in_chunks()
     {
-        $import = new class implements ToModel, WithChunkReading, RemembersRowNumber {
+        $import = new class implements ToModel, WithChunkReading {
             use Importable;
+            use RemembersRowNumber;
 
-            private $rowNumber;
             public $rowNumbers = [];
 
             public function chunkSize(): int
@@ -77,12 +67,7 @@ class RemembersRowNumberTest extends TestCase
 
             public function model(array $row)
             {
-                $this->rowNumbers[] = $this->rowNumber;
-            }
-
-            public function setRowNumber(int $rowNumber)
-            {
-                $this->rowNumber = $rowNumber;
+                $this->rowNumbers[] = $this->getRowNumber();
             }
         };
 
@@ -96,10 +81,10 @@ class RemembersRowNumberTest extends TestCase
      */
     public function can_access_row_number_on_import_to_array_in_chunks_with_batch_inserts()
     {
-        $import = new class implements ToModel, WithChunkReading, WithBatchInserts, RemembersRowNumber {
+        $import = new class implements ToModel, WithChunkReading, WithBatchInserts {
             use Importable;
+            use RemembersRowNumber;
 
-            private $rowNumber;
             public $rowNumbers = [];
 
             public function chunkSize(): int
@@ -115,11 +100,6 @@ class RemembersRowNumberTest extends TestCase
             public function batchSize(): int
             {
                 return 50;
-            }
-
-            public function setRowNumber(int $rowNumber)
-            {
-                $this->rowNumber = $rowNumber;
             }
         };
 

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Maatwebsite\Excel\Concerns\Importable;
-use Maatwebsite\Excel\Concerns\RemembersChunkOffset;
 use Maatwebsite\Excel\Concerns\RemembersRowNumber;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
@@ -74,5 +73,4 @@ class RemembersRowNumberTest extends TestCase
 
         $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
     }
-
 }

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -5,6 +5,7 @@ namespace Maatwebsite\Excel\Tests\Concerns;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\RemembersRowNumber;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Tests\TestCase;
 
@@ -66,6 +67,39 @@ class RemembersRowNumberTest extends TestCase
             public function model(array $row)
             {
                 $this->rowNumbers[] = $this->getRowNumber();
+            }
+        };
+
+        $import->import('import-batches.xlsx');
+
+        $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
+    }
+
+
+    /**
+     * @test
+     */
+    public function can_access_row_number_on_import_to_array_in_chunks_with_batch_inserts()
+    {
+        $import = new class implements ToModel, WithChunkReading, WithBatchInserts {
+            use Importable;
+            use RemembersRowNumber;
+
+            public $rowNumbers = [];
+
+            public function chunkSize(): int
+            {
+                return 50;
+            }
+
+            public function model(array $row)
+            {
+                $this->rowNumbers[] = $this->getRowNumber();
+            }
+
+            public function batchSize(): int
+            {
+                return 50;
             }
         };
 

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -75,7 +75,6 @@ class RemembersRowNumberTest extends TestCase
         $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
     }
 
-
     /**
      * @test
      */


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

Added RemembersRowNumber Trait to keep track of the "current" Row Number.

The Feature was discussed [here](https://github.com/Maatwebsite/Laravel-Excel/pull/2637#issuecomment-617947013)

[Documentation PR](https://github.com/Maatwebsite/laravel-excel-docs/pull/99)

### Why Should This Be Added?

It provides easy access to the current row number while importing.

### Benefits

There are multiple usecases for this feature.

One would be adding a custom Validation in the `->model($row)` while knowing which row is validated.

### Possible Drawbacks

Works only for "ToModel" Interface

### Verification Process

Added Tests.

Have not tested it manually yet.

### Applicable Issues


