### PR TITLE
Remove temp file on failure

### DIFF
--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -148,6 +148,8 @@ class ReadChunk implements ShouldQueue
      */
     public function failed(Throwable $e)
     {
+        $this->temporaryFile->delete();
+
         if ($this->import instanceof WithEvents) {
             $this->registerListeners($this->import->registerEvents());
             $this->raise(new ImportFailed($e));

--- a/tests/Data/Stubs/QueuedImportWithFailure.php
+++ b/tests/Data/Stubs/QueuedImportWithFailure.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithBatchInserts;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\ImportFailed;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
+
+class QueuedImportWithFailure implements ShouldQueue, ToModel, WithChunkReading
+{
+    use Importable;
+
+    /**
+     * @param array $row
+     *
+     * @return Model|null
+     */
+    public function model(array $row)
+    {
+        throw new \Exception('Something went wrong in the chunk');
+
+        return new Group([
+            'name' => $row[0],
+        ]);
+    }
+
+    /**
+     * @return int
+     */
+    public function chunkSize(): int
+    {
+        return 100;
+    }
+}

--- a/tests/Data/Stubs/QueuedImportWithFailure.php
+++ b/tests/Data/Stubs/QueuedImportWithFailure.php
@@ -6,10 +6,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToModel;
-use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
-use Maatwebsite\Excel\Concerns\WithEvents;
-use Maatwebsite\Excel\Events\ImportFailed;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 
 class QueuedImportWithFailure implements ShouldQueue, ToModel, WithChunkReading

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -2,16 +2,11 @@
 
 namespace Maatwebsite\Excel\Tests;
 
-use Exception;
 use Illuminate\Foundation\Bus\PendingDispatch;
-use Illuminate\Foundation\Testing\Assert;
 use Illuminate\Queue\Events\JobExceptionOccurred;
-use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Support\Facades\Queue;
 use Maatwebsite\Excel\Concerns\Importable;
-use Maatwebsite\Excel\Concerns\ToModel;
-use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Files\RemoteTemporaryFile;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Jobs\ReadChunk;

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -17,6 +17,7 @@ use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Jobs\ReadChunk;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueImportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImport;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithFailure;
 use Throwable;
 
 class QueuedImportTest extends TestCase
@@ -147,7 +148,7 @@ class QueuedImportTest extends TestCase
         });
 
         try {
-            (new QueuedImport())->queue('import-batches.xlsx');
+            (new QueuedImportWithFailure())->queue('import-batches.xlsx');
         } catch (Throwable $e) {
             $this->assertEquals('Something went wrong in the chunk', $e->getMessage());
         }


### PR DESCRIPTION
### Requirements

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation. (Not applicable)
* [x] Added tests to ensure against regression.

### Description of the Change

Removes the temporary local file in the case of a failed import.

### Why Should This Be Added?

In the case of a failed export, the temporary file is left on the server. This is particularly problematic if dealing with low space and or a high volume of imports. I encountered this issue when using Laravel Vapor. I posted a question about this here https://github.com/Maatwebsite/Laravel-Excel/issues/2655, this PR is an attempt to fix one of the issues outlined in the question.

### Benefits

Failed files won't be stored on the server.

### Possible Drawbacks

I presume if a failed job is retried in the future a new copy of the file would have to be fetched. 

### Verification Process

I have written a test to confirm the issue is fixed before and after the fix was applied. I have run the test suite and have confirmed it was all passing on my machine.

### Applicable Issues

https://github.com/Maatwebsite/Laravel-Excel/issues/2655
