### PR TITLE
Only delete the local temp file on failure when using remote disk

### DIFF
--- a/src/Files/RemoteTemporaryFile.php
+++ b/src/Files/RemoteTemporaryFile.php
@@ -54,6 +54,14 @@ class RemoteTemporaryFile extends TemporaryFile
     /**
      * @return bool
      */
+    public function existsLocally(): bool
+    {
+        return $this->localTemporaryFile->exists();
+    }
+
+    /**
+     * @return bool
+     */
     public function exists(): bool
     {
         return $this->disk()->exists($this->filename);
@@ -62,9 +70,17 @@ class RemoteTemporaryFile extends TemporaryFile
     /**
      * @return bool
      */
+    public function deleteLocalCopy(): bool
+    {
+        return $this->localTemporaryFile->delete();
+    }
+
+    /**
+     * @return bool
+     */
     public function delete(): bool
     {
-        $this->localTemporaryFile->delete();
+        $this->deleteLocalCopy();
 
         return $this->disk()->delete($this->filename);
     }

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -8,6 +8,7 @@ use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\ImportFailed;
+use Maatwebsite\Excel\Files\RemoteTemporaryFile;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Filters\ChunkReadFilter;
 use Maatwebsite\Excel\HasEventBus;
@@ -148,7 +149,9 @@ class ReadChunk implements ShouldQueue
      */
     public function failed(Throwable $e)
     {
-        $this->temporaryFile->delete();
+        if($this->temporaryFile instanceof RemoteTemporaryFile) {
+            $this->temporaryFile->deleteLocalCopy();
+        }
 
         if ($this->import instanceof WithEvents) {
             $this->registerListeners($this->import->registerEvents());

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -149,7 +149,7 @@ class ReadChunk implements ShouldQueue
      */
     public function failed(Throwable $e)
     {
-        if($this->temporaryFile instanceof RemoteTemporaryFile) {
+        if ($this->temporaryFile instanceof RemoteTemporaryFile) {
             $this->temporaryFile->deleteLocalCopy();
         }
 


### PR DESCRIPTION
### Requirements

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation. (Not applicable)
* [x] Added tests to ensure against regression.

### Description of the Change

This is an amendment to the PR submitted here https://github.com/Maatwebsite/Laravel-Excel/pull/2663 by myself. In the case of applications not using a remote disk I think it's incorrect to blindly remove the local file thus making it impossible for them to retry failed jobs. When using the remote disk we have a copy of the temporary file to retry the failed jobs with. 

In either case the previous PR made it difficult to retry failed jobs on failure as the temporary file would be removed in either use case both when using remote disk or local disk.

### Why Should This Be Added?

This should be added so that applications using a remote disk don't have their local temp storage over crowded with duplicate files that are already stored on the remote disk.

### Benefits

Applications using remote disk for storage concerns won't have their local storage compromised by failed imports.

### Possible Drawbacks

I presume if a failed job is retried in the future a new copy of the file would have to be fetched.

### Verification Process

I have updated previous test to confirm the issue is fixed before and after the fix was applied. I have also added a test to confirm when not using remote disk, that the local file remains in place. I have run the test suite and have confirmed that it was all passing on my machine.

### Applicable Issues

https://github.com/Maatwebsite/Laravel-Excel/issues/2655
