### PR TITLE
Add config setting for vapor

### DIFF
--- a/config/excel.php
+++ b/config/excel.php
@@ -182,5 +182,21 @@ return [
         'remote_disk'   => null,
         'remote_prefix' => null,
 
+        /*
+        |--------------------------------------------------------------------------
+        | Force Resync
+        |--------------------------------------------------------------------------
+        |
+        | When dealing with a multi server setup as above, it's possible
+        | for the clean up that occurs after entire queue has been run to only
+        | cleanup the server that the last AfterImportJob runs on. The rest of the server
+        | would still have the local temporary file stored on it. In this case your
+        | local storage limits can be exceeded and future imports won't be processed.
+        | To mitigate this you can set this config value to be true, so that after every
+        | queued chunk is processed the local temporary file is deleted on the server that
+        | processed it.
+        |
+        */
+        'force_resync_remote' => null,
     ],
 ];

--- a/src/Files/RemoteTemporaryFile.php
+++ b/src/Files/RemoteTemporaryFile.php
@@ -80,7 +80,10 @@ class RemoteTemporaryFile extends TemporaryFile
      */
     public function delete(): bool
     {
-        $this->deleteLocalCopy();
+        // we don't need to delete local copy as it's deleted at end of each chunk
+        if(!config('excel.temporary_files.force_resync_remote')) {
+            $this->deleteLocalCopy();
+        }
 
         return $this->disk()->delete($this->filename);
     }

--- a/src/Files/RemoteTemporaryFile.php
+++ b/src/Files/RemoteTemporaryFile.php
@@ -81,7 +81,7 @@ class RemoteTemporaryFile extends TemporaryFile
     public function delete(): bool
     {
         // we don't need to delete local copy as it's deleted at end of each chunk
-        if(!config('excel.temporary_files.force_resync_remote')) {
+        if (!config('excel.temporary_files.force_resync_remote')) {
             $this->deleteLocalCopy();
         }
 

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -169,11 +169,11 @@ class ReadChunk implements ShouldQueue
 
     private function cleanUpTempFile()
     {
-        if(!config('excel.temporary_files.force_resync_remote')) {
+        if (!config('excel.temporary_files.force_resync_remote')) {
             return true;
         }
 
-        if(!$this->temporaryFile instanceof RemoteTemporaryFile) {
+        if (!$this->temporaryFile instanceof RemoteTemporaryFile) {
             return true;
         }
 

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -131,6 +131,8 @@ class ReadChunk implements ShouldQueue
         if ($sheet->getHighestRow() < $this->startRow) {
             $sheet->disconnect();
 
+            $this->cleanUpTempFile();
+
             return;
         }
 
@@ -141,6 +143,8 @@ class ReadChunk implements ShouldQueue
             );
 
             $sheet->disconnect();
+
+            $this->cleanUpTempFile();
         });
     }
 
@@ -161,5 +165,18 @@ class ReadChunk implements ShouldQueue
                 $this->import->failed($e);
             }
         }
+    }
+
+    private function cleanUpTempFile()
+    {
+        if(!config('excel.temporary_files.force_resync_remote')) {
+            return true;
+        }
+
+        if(!$this->temporaryFile instanceof RemoteTemporaryFile) {
+            return true;
+        }
+
+        return $this->temporaryFile->deleteLocalCopy();
     }
 }

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -6,10 +6,12 @@ use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Files\RemoteTemporaryFile;
 use Maatwebsite\Excel\Files\TemporaryFile;
+use Maatwebsite\Excel\Jobs\AfterImportJob;
 use Maatwebsite\Excel\Jobs\ReadChunk;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueImportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImport;
@@ -183,6 +185,7 @@ class QueuedImportTest extends TestCase
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
         config()->set('excel.temporary_files.force_resync_remote', true);
+        Bus::fake([AfterImportJob::class]);
 
         Queue::after(function (JobProcessed $event) {
             if ($event->job->resolveName() === ReadChunk::class) {

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -4,6 +4,7 @@ namespace Maatwebsite\Excel\Tests;
 
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Support\Facades\Queue;
 use Maatwebsite\Excel\Concerns\Importable;
@@ -173,5 +174,27 @@ class QueuedImportTest extends TestCase
         }
 
         $this->assertTrue($tempFile->exists());
+    }
+
+    /**
+     * @test
+     */
+    public function can_force_remote_download_and_deletion_for_each_chunk_on_queue()
+    {
+        config()->set('excel.temporary_files.remote_disk', 'test');
+        config()->set('excel.temporary_files.force_resync_remote', true);
+
+        Queue::after(function (JobProcessed $event) {
+            if ($event->job->resolveName() === ReadChunk::class) {
+                $tempFile = $this->inspectJobProperty($event->job, 'temporaryFile');
+
+                // Should not exist locally after each chunk
+                $this->assertFalse(
+                    $tempFile->existsLocally()
+                );
+            }
+        });
+
+        (new QueuedImport())->queue('import-batches.xlsx');
     }
 }


### PR DESCRIPTION
* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation. (PR Pending in documentation repo)
* [x] Added tests to ensure against regression.

### Description of the Change

Added a setting to force deletion of the local temporary file when using a remote disk and queued chunked imports.

### Why Should This Be Added?

When dealing with a multi server setup as above, it's possible for the clean up that occurs after entire queue has been run to only cleanup the server that the last AfterImportJob runs on. The rest of the server would still have the local temporary file stored on it. In this case your local storage limits can be exceeded and future imports won't be processed. To mitigate this you can set this config value to be true, so that after every queued chunk is processed the local temporary file is deleted on the server that processed it.

### Benefits

Potential storage side effects can be mitigated. See the following issue for context and discussion of proposed changes https://github.com/Maatwebsite/Laravel-Excel/issues/2655

### Possible Drawbacks

Fresh file will need to be downloaded locally for each chunk.

### Verification Process

I have added a test for the proposed setting and ensured test was failing before implementing required changes, and ensured it and whole suite now passes.

### Applicable Issues

https://github.com/Maatwebsite/Laravel-Excel/issues/2655

