### PR TITLE
Add middleware to imports

### DIFF
--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -91,6 +91,16 @@ class ReadChunk implements ShouldQueue
     }
 
     /**
+     * Get the middleware the job should be dispatched through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return (method_exists($this->import, 'middleware')) ? $this->import->middleware() : [];
+    }
+
+    /**
      * @param  TransactionHandler  $transaction
      *
      * @throws \Maatwebsite\Excel\Exceptions\SheetNotFoundException

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -101,6 +101,16 @@ class ReadChunk implements ShouldQueue
     }
 
     /**
+     * Determine the time at which the job should timeout.
+     *
+     * @return \DateTime
+     */
+    public function retryUntil()
+    {
+        return (method_exists($this->import, 'retryUntil')) ? $this->import->retryUntil() : null;
+    }
+
+    /**
      * @param  TransactionHandler  $transaction
      *
      * @throws \Maatwebsite\Excel\Exceptions\SheetNotFoundException

--- a/tests/Data/Stubs/QueuedImportWithMiddleware.php
+++ b/tests/Data/Stubs/QueuedImportWithMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
+
+class QueuedImportWithMiddleware implements ShouldQueue, ToModel, WithChunkReading
+{
+    use Importable;
+
+    /**
+     * @param array $row
+     *
+     * @return Model|null
+     */
+    public function model(array $row)
+    {
+        return new Group([
+            'name' => $row[0],
+        ]);
+    }
+
+    public function middleware()
+    {
+        return [function() {
+            throw new \Exception('Job reached middleware method');
+        }];
+    }
+
+    /**
+     * @return int
+     */
+    public function chunkSize(): int
+    {
+        return 100;
+    }
+}

--- a/tests/Data/Stubs/QueuedImportWithMiddleware.php
+++ b/tests/Data/Stubs/QueuedImportWithMiddleware.php
@@ -27,7 +27,7 @@ class QueuedImportWithMiddleware implements ShouldQueue, ToModel, WithChunkReadi
 
     public function middleware()
     {
-        return [function() {
+        return [function () {
             throw new \Exception('Job reached middleware method');
         }];
     }

--- a/tests/Data/Stubs/QueuedImportWithMiddlewareException.php
+++ b/tests/Data/Stubs/QueuedImportWithMiddlewareException.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
+
+class QueuedImportWithMiddlewareException implements ShouldQueue, ToModel, WithChunkReading
+{
+    use Importable;
+
+    /**
+     * @param array $row
+     *
+     * @return Model|null
+     */
+    public function model(array $row)
+    {
+        return new Group([
+            'name' => $row[0],
+        ]);
+    }
+
+    public function middleware()
+    {
+        return [function() {
+            throw new \Exception('Something went wrong in the middleware');
+        }];
+    }
+
+    /**
+     * @return int
+     */
+    public function chunkSize(): int
+    {
+        return 100;
+    }
+}

--- a/tests/Data/Stubs/QueuedImportWithRetryUntil.php
+++ b/tests/Data/Stubs/QueuedImportWithRetryUntil.php
@@ -9,7 +9,7 @@ use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 
-class QueuedImportWithMiddlewareException implements ShouldQueue, ToModel, WithChunkReading
+class QueuedImportWithRetryUntil implements ShouldQueue, ToModel, WithChunkReading
 {
     use Importable;
 
@@ -25,18 +25,23 @@ class QueuedImportWithMiddlewareException implements ShouldQueue, ToModel, WithC
         ]);
     }
 
-    public function middleware()
-    {
-        return [function() {
-            throw new \Exception('Something went wrong in the middleware');
-        }];
-    }
-
     /**
      * @return int
      */
     public function chunkSize(): int
     {
         return 100;
+    }
+
+    /**
+     * Determine the time at which the job should timeout.
+     *
+     * @return \DateTime
+     */
+    public function retryUntil()
+    {
+        throw new \Exception('Job reached retryUntil method');
+
+        return now()->addSeconds(5);
     }
 }

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -227,4 +227,3 @@ class QueuedImportTest extends TestCase
         }
     }
 }
-

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -16,6 +16,7 @@ use Maatwebsite\Excel\Jobs\ReadChunk;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueImportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithFailure;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithMiddlewareException;
 use Throwable;
 
 class QueuedImportTest extends TestCase
@@ -200,4 +201,17 @@ class QueuedImportTest extends TestCase
 
         (new QueuedImport())->queue('import-batches.xlsx');
     }
+
+    /**
+     * @test
+     */
+    public function can_add_middleware_to_a_queued_import()
+    {
+        try {
+            (new QueuedImportWithMiddlewareException())->queue('import-batches.xlsx');
+        } catch (Throwable $e) {
+            $this->assertEquals('Something went wrong in the middleware', $e->getMessage());
+        }
+    }
 }
+

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -17,7 +17,6 @@ use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueImportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithFailure;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithMiddleware;
-use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithMiddlewareException;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithRetryUntil;
 use Throwable;
 

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -16,7 +16,9 @@ use Maatwebsite\Excel\Jobs\ReadChunk;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueImportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithFailure;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithMiddleware;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithMiddlewareException;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithRetryUntil;
 use Throwable;
 
 class QueuedImportTest extends TestCase
@@ -205,12 +207,24 @@ class QueuedImportTest extends TestCase
     /**
      * @test
      */
-    public function can_add_middleware_to_a_queued_import()
+    public function can_define_middleware_method_on_queued_import()
     {
         try {
-            (new QueuedImportWithMiddlewareException())->queue('import-batches.xlsx');
+            (new QueuedImportWithMiddleware())->queue('import-batches.xlsx');
         } catch (Throwable $e) {
-            $this->assertEquals('Something went wrong in the middleware', $e->getMessage());
+            $this->assertEquals('Job reached middleware method', $e->getMessage());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_define_retry_until_method_on_queued_import()
+    {
+        try {
+            (new QueuedImportWithRetryUntil())->queue('import-batches.xlsx');
+        } catch (Throwable $e) {
+            $this->assertEquals('Job reached retryUntil method', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation. (PR Pending)
* [x] Added tests to ensure against regression.

### Description of the Change

As per an earlier PR https://github.com/Maatwebsite/Laravel-Excel/pull/2420 that added middleware to exports, this PR seeks to add this functionality to Imports.

### Why Should This Be Added?

To help maintain symmetry of features between imports and exports. As well as add features to queued imports that exist in Laravel 7.x.

### Benefits

You will be able to add middleware to queued imports https://laravel.com/docs/7.x/queues#job-middleware

### Possible Drawbacks

The method of verifying the middleware is added as well as the retryUntil method while functional is a bit ad-hoc. I think the tests function fine and are quite understandable. However if there is a better way to assert the import transfers those method to the job then I'd be happy to look into it further.

### Verification Process

I wrote tests to assert that they failed, then added functionality to ensure they passed. I have also run the whole test suite to help ensure no regressions were introduced in the process.

### Applicable Issues

No applicable issues.