### PR TITLE
Fixing issue #2619

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -531,11 +531,11 @@ class Sheet
             if ($sheetExport instanceof WithMapping) {
                 $row = $sheetExport->map($row);
             }
-            
+
             if ($sheetExport instanceof WithCustomValueBinder) {
                 SpreadsheetCell::setValueBinder($sheetExport);
             }
-            
+
             return ArrayHelper::ensureMultipleRows(
                 static::mapArraybleRow($row)
             );

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -531,7 +531,11 @@ class Sheet
             if ($sheetExport instanceof WithMapping) {
                 $row = $sheetExport->map($row);
             }
-
+            
+            if ($sheetExport instanceof WithCustomValueBinder) {
+                SpreadsheetCell::setValueBinder($sheetExport);
+            }
+            
             return ArrayHelper::ensureMultipleRows(
                 static::mapArraybleRow($row)
             );


### PR DESCRIPTION
### Requirements

Mark the following tasks as done:

* [ x] Checked the codebase to ensure that your feature doesn't already exist.
* [ x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

Not sure if this is the right spot - however it fixes the issue: #2619 - It seems the open function is skipped when queueing to an existing file. Thus the ValueBinder is not set when appending rows.


### Why Should This Be Added?

ValueBinder gets ignored if Excel export is queued.

### Benefits

ValueBinder is set when queueing

### Possible Drawbacks

no tests yet

### Verification Process

Testing on local machine

### Applicable Issues

#2619 
