### PR TITLE
Add interacts with queue trait to jobs

### DIFF
--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -4,6 +4,7 @@ namespace Maatwebsite\Excel\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 use Maatwebsite\Excel\Concerns\WithEvents;
@@ -21,7 +22,7 @@ use Throwable;
 
 class ReadChunk implements ShouldQueue
 {
-    use Queueable, HasEventBus;
+    use Queueable, HasEventBus, InteractsWithQueue;
 
     /**
      * @var int

--- a/tests/ReadChunkTest.php
+++ b/tests/ReadChunkTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests;
+
+use Illuminate\Queue\InteractsWithQueue;
+use Maatwebsite\Excel\Jobs\ReadChunk;
+
+class ReadChunkTest extends TestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function read_chunk_job_can_interact_with_queue()
+    {
+        $this->assertContains(InteractsWithQueue::class, class_uses(ReadChunk::class));
+    }
+}


### PR DESCRIPTION
* [X] Checked the codebase to ensure that your feature doesn't already exist.
* [X] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [X] Adjusted the Documentation. (not applicable)
* [X] Added tests to ensure against regression.

### Description of the Change

Added the ability for the read chunk job to interact with the queue via the laravel trait. 

### Why Should This Be Added?

The trait allows for the job to be released back onto the queue, useful for instance if using it with the funnel or throttle methods on the Redis facade.

### Benefits

Allows for usage with the Redis facade.

### Possible Drawbacks

None that I'm aware of, but I have limited the scope of the trait to only the ReadChunk class rather than all jobs, so if there are issues hopefully they will be narrower in scope.

### Verification Process

I've added a test and ensured it and the suite was passing. I was unsure of placement of test as I created a new file, we don't seem to have a Unit test folder in the project? Is it desirable to write unit tests. Happy to delete it if it's uneeded.

### Applicable Issues

None
