### PR TITLE
Add UploadedFile typehints to Excel Facade

### DIFF
--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel\Facades;
 
 use Illuminate\Foundation\Bus\PendingDispatch;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
 use Maatwebsite\Excel\Excel as BaseExcel;
@@ -13,10 +14,10 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
  * @method static BinaryFileResponse download(object $export, string $fileName, string $writerType = null, array $headers = [])
  * @method static bool store(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
  * @method static PendingDispatch queue(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
- * @method static BaseExcel import(object $import, string $filePath, string $disk = null, string $readerType = null)
- * @method static array toArray(object $import, string $filePath, string $disk = null, string $readerType = null)
- * @method static Collection toCollection(object $import, string $filePath, string $disk = null, string $readerType = null)
- * @method static PendingDispatch queueImport(object $import, string $filePath, string $disk = null, string $readerType = null)
+ * @method static BaseExcel import(object $import, string|UploadedFile $filePath, string $disk = null, string $readerType = null)
+ * @method static array toArray(object $import, string|UploadedFile $filePath, string $disk = null, string $readerType = null)
+ * @method static Collection toCollection(object $import, string|UploadedFile $filePath, string $disk = null, string $readerType = null)
+ * @method static PendingDispatch queueImport(object $import, string|UploadedFile $filePath, string $disk = null, string $readerType = null)
  * @method static void matchByRegex()
  * @method static void doNotMatchByRegex()
  * @method static void assertDownloaded(string $fileName, callable $callback = null)


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

I've added the `Illuminate\Http\UploadedFile` class as a typehint in the Excel Facade comment for the `import`,`toArray`, `toCollection` and `queueImport` method.

### Why Should This Be Added?

<!-- Explain why this functionality should be added in Laravel-Excel -->

### Benefits

IDE's will not throw error lines when injecting an UploadedFile instead of a string.

### Possible Drawbacks

None

### Verification Process

```php
\Maatwebsite\Excel\Facades\Excel::import(new ImportClass, $request->file('example_file'));
\Maatwebsite\Excel\Facades\Excel::toArray(new ImportClass, $request->file('example_file'));
\Maatwebsite\Excel\Facades\Excel::toCollection(new ImportClass, $request->file('example_file'));
\Maatwebsite\Excel\Facades\Excel::queueImport(new ImportClass, $request->file('example_file'));
```
