### PR TITLE
Include empty columns in csv export

### DIFF
--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -163,8 +163,8 @@ class ExcelTest extends TestCase
             public function collection()
             {
                 return collect([
-                    ['A1', 'B1'],
-                    ['A2', 'B2'],
+                    ['A1', 'B1', '', ''],
+                    ['A2', 'B2', '', ''],
                 ]);
             }
 
@@ -188,8 +188,8 @@ class ExcelTest extends TestCase
         $contents = file_get_contents(__DIR__ . '/Data/Disks/Local/filename.csv');
 
         $this->assertStringContains('sep=;', $contents);
-        $this->assertStringContains('"A1";"B1"', $contents);
-        $this->assertStringContains('"A2";"B2"', $contents);
+        $this->assertStringContains('"A1";"B1";;', $contents);
+        $this->assertStringContains('"A2";"B2";;', $contents);
     }
 
     /**


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

Edited the `can_store_csv_export_with_custom_settings` test to include some empty columns at the end of rows.

### Why Should This Be Added?

When exporting a CSV that is used as import in another tool. it should contain the right amount of columns and not cut off empty columns at the end of a row.

### Benefits

Improved stability and interoperability

### Possible Drawbacks

-

### Verification Process

Only edited test that should fail, as requested by repo owner.

### Applicable Issues

-
