### PR TITLE
Laravel 8 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,10 +24,12 @@ jobs:
     strategy:
       matrix:
         php: [7.4, 7.3]
-        laravel: [7.*, 6.*, 5.8.*]
+        laravel: [8.*, 7.*, 6.*, 5.8.*]
         dependency-version: [prefer-stable]
         os: [ubuntu-latest]
         include:
+          - laravel: 8.*
+            testbench: dev-master
           - laravel: 7.*
             testbench: 5.*
           - laravel: 6.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 7.3, 7.2]
+        php: [7.4, 7.3]
         laravel: [7.*, 6.*, 5.8.*]
         dependency-version: [prefer-stable]
         os: [ubuntu-latest]

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": "^7.0",
+    "php": "^7.3",
     "phpoffice/phpspreadsheet": "^1.14",
-    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0"
+    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "orchestra/testbench": "^5.0",


### PR DESCRIPTION
Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Updated CHANGELOG.md
* [ ] Added tests to ensure against regression.

### Description of the Change

This PR adds support for laravel 8. I also removed php7.2 from the test matrix since it is no longer supported by laravel 8.

### Breaking changes

- PHP 7.2 is no longer supported. (See https://laravel.com/docs/master/upgrade#php-7.3.0-required)