### PR TITLE
Allow imports to configure the validator instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added support for `withValidator` on `WithValidation` concern
+
 ## [3.1.23] - 2020-09-29
 
 ### Added

--- a/src/Validators/RowValidator.php
+++ b/src/Validators/RowValidator.php
@@ -38,7 +38,13 @@ class RowValidator
         $attributes = $this->attributes($import);
 
         try {
-            $this->validator->make($rows, $rules, $messages, $attributes)->validate();
+            $validator = $this->validator->make($rows, $rules, $messages, $attributes);
+
+            if (method_exists($import, 'withValidator')) {
+                $import->withValidator($validator);
+            }
+
+            $validator->validate();
         } catch (IlluminateValidationException $e) {
             $failures = [];
             foreach ($e->errors() as $attribute => $messages) {


### PR DESCRIPTION
* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Updated CHANGELOG.md
* [x] Added tests to ensure against regression.

### Description of the Change

This PR allows imports implementing `WithValidation` to configure their validator.

### Why Should This Be Added?

See #2873 

### Benefits

- Enables usages of validator methods such as `Validator::sometimes(...)` and `Validator::after(...)`

### Possible Drawbacks

- This feature does not use a "marker interface" to enforce the withValidator method, this is because this is the most inline with Laravel's `FormRequest`, however this also means that if someone is already implementing this method on their import the change may break their code
- Because each import is usually validated in a chunked manner, not all rows are available to the validator at the same time, this means that direct references to rows e.g. `$validator->errors()->add('100.email', ...)` are not supported

### Verification Process
TODO
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

-->

### Applicable Issues

#2873 
