### PR TITLE
Allow imports to manipulate data before it is validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added support for `prepareForValidation` on `WithValidation` concern
 - Added support for `withValidator` on `WithValidation` concern
 
 ## [3.1.23] - 2020-09-29

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -8,6 +8,7 @@ use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
 use Maatwebsite\Excel\Concerns\WithColumnLimit;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithProgressBar;
+use Maatwebsite\Excel\Concerns\WithValidation;
 use Maatwebsite\Excel\Row;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
@@ -46,6 +47,7 @@ class ModelImporter
         $progessBar       = $import instanceof WithProgressBar;
         $withMapping      = $import instanceof WithMapping;
         $withCalcFormulas = $import instanceof WithCalculatedFormulas;
+        $withValidation   = $import instanceof WithValidation && method_exists($import, 'prepareForValidation');
         $endColumn        = $import instanceof WithColumnLimit ? $import->endColumn() : null;
 
         $this->manager->setRemembersRowNumber(method_exists($import, 'rememberRowNumber'));
@@ -56,6 +58,10 @@ class ModelImporter
 
             $row      = new Row($spreadSheetRow, $headingRow);
             $rowArray = $row->toArray(null, $withCalcFormulas, true, $endColumn);
+
+            if ($withValidation) {
+                $rowArray = $import->prepareForValidation($rowArray, $row->getIndex());
+            }
 
             if ($withMapping) {
                 $rowArray = $import->map($rowArray);

--- a/src/Row.php
+++ b/src/Row.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel;
 
 use ArrayAccess;
+use Closure;
 use Illuminate\Support\Collection;
 use PhpOffice\PhpSpreadsheet\Worksheet\Row as SpreadsheetRow;
 
@@ -14,6 +15,11 @@ class Row implements ArrayAccess
      * @var array
      */
     protected $headingRow = [];
+
+    /**
+     * @var \Closure
+     */
+    protected $preparationCallback;
 
     /**
      * @var SpreadsheetRow
@@ -86,6 +92,10 @@ class Row implements ArrayAccess
             $i++;
         }
 
+        if (isset($this->preparationCallback)) {
+            $cells = ($this->preparationCallback)($cells, $this->row->getRowIndex());
+        }
+
         $this->rowCache = $cells;
 
         return $cells;
@@ -117,5 +127,14 @@ class Row implements ArrayAccess
     public function offsetUnset($offset)
     {
         //
+    }
+
+    /**
+     * @param \Closure $preparationCallback
+     * @internal
+     */
+    public function setPreparationCallback(Closure $preparationCallback = null)
+    {
+        $this->preparationCallback = $preparationCallback;
     }
 }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel;
 
+use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\FromArray;
@@ -282,13 +283,15 @@ class Sheet
         }
 
         if ($import instanceof OnEachRow) {
-            $headingRow = HeadingRowExtractor::extract($this->worksheet, $import);
-            $endColumn  = $import instanceof WithColumnLimit ? $import->endColumn() : null;
+            $headingRow          = HeadingRowExtractor::extract($this->worksheet, $import);
+            $endColumn           = $import instanceof WithColumnLimit ? $import->endColumn() : null;
+            $preparationCallback = $this->getPreparationCallback($import);
 
             foreach ($this->worksheet->getRowIterator()->resetStart($startRow ?? 1) as $row) {
                 $sheetRow = new Row($row, $headingRow);
 
                 if ($import instanceof WithValidation) {
+                    $sheetRow->setPreparationCallback($preparationCallback);
                     $toValidate = [$sheetRow->getIndex() => $sheetRow->toArray(null, $import instanceof WithCalculatedFormulas, $endColumn)];
 
                     try {
@@ -713,5 +716,20 @@ class Sheet
         }
 
         return $this->chunkSize;
+    }
+
+    /**
+     * @param object|WithValidation $import
+     * @return Closure|null
+     */
+    private function getPreparationCallback($import)
+    {
+        if (!$import instanceof WithValidation || !method_exists($import, 'prepareForValidation')) {
+            return null;
+        }
+
+        return function (array $data, int $index) use ($import) {
+            return $import->prepareForValidation($data, $index);
+        };
     }
 }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -333,11 +333,15 @@ class Sheet
         $endColumn  = $import instanceof WithColumnLimit ? $import->endColumn() : null;
 
         $rows = [];
-        foreach ($this->worksheet->getRowIterator($startRow, $endRow) as $row) {
+        foreach ($this->worksheet->getRowIterator($startRow, $endRow) as $index => $row) {
             $row = (new Row($row, $headingRow))->toArray($nullValue, $calculateFormulas, $formatData, $endColumn);
 
             if ($import instanceof WithMapping) {
                 $row = $import->map($row);
+            }
+
+            if ($import instanceof WithValidation && method_exists($import, 'prepareForValidation')) {
+                $row = $import->prepareForValidation($row, $index);
             }
 
             $rows[] = $row;

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -820,6 +820,71 @@ class WithValidationTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function can_prepare_using_oneachrow()
+    {
+        $import = new class implements OnEachRow, WithValidation {
+            use Importable;
+
+            /**
+             * @return array
+             */
+            public function rules(): array
+            {
+                return [
+                    '1' => 'email',
+                ];
+            }
+
+            /**
+             * Prepare the data for validation.
+             *
+             * @param array $row
+             * @param int $index
+             * @return array
+             */
+            public function prepareForValidation(array $row, int $index)
+            {
+                if ($index === 2) {
+                    $row[1] = 'not an email';
+                }
+
+                return $row;
+            }
+
+            /**
+             * @param \Maatwebsite\Excel\Row $row
+             * @return void
+             */
+            public function onRow(Row $row)
+            {
+                User::query()->create([
+                    'name' => $row[0],
+                    'email' => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+        };
+
+        try {
+            $import->import('import-users.xlsx');
+        } catch (ValidationException $e) {
+            $this->validateFailure($e, 2, '1', [
+                'The 1 must be a valid email address.',
+            ]);
+
+            $this->assertEquals([
+                [
+                    'There was an error on row 2. The 1 must be a valid email address.',
+                ],
+            ], $e->errors());
+        }
+
+        $this->assertInstanceOf(ValidationException::class, $e ?? null);
+    }
+
+    /**
      * @param ValidationException $e
      * @param int                 $row
      * @param string              $attribute

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -795,8 +795,8 @@ class WithValidationTest extends TestCase
             public function model(array $row)
             {
                 return new User([
-                    'name' => $row[0],
-                    'email' => $row[1],
+                    'name'     => $row[0],
+                    'email'    => $row[1],
                     'password' => 'secret',
                 ]);
             }
@@ -860,8 +860,8 @@ class WithValidationTest extends TestCase
             public function onRow(Row $row)
             {
                 User::query()->create([
-                    'name' => $row[0],
-                    'email' => $row[1],
+                    'name'     => $row[0],
+                    'email'    => $row[1],
                     'password' => 'secret',
                 ]);
             }

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -633,6 +633,193 @@ class WithValidationTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function can_prepare_using_toarray()
+    {
+        $import = new class implements ToArray, WithValidation {
+            use Importable;
+
+            /**
+             * @return array
+             */
+            public function rules(): array
+            {
+                return [
+                    '1' => 'email',
+                ];
+            }
+
+            /**
+             * Prepare the data for validation.
+             *
+             * @param array $row
+             * @param int $index
+             * @return array
+             */
+            public function prepareForValidation(array $row, int $index)
+            {
+                if ($index === 2) {
+                    $row[1] = 'not an email';
+                }
+
+                return $row;
+            }
+
+            /**
+             * @param array $array
+             * @return array
+             */
+            public function array(array $array)
+            {
+                return [];
+            }
+        };
+
+        try {
+            $import->import('import-users.xlsx');
+        } catch (ValidationException $e) {
+            $this->validateFailure($e, 2, '1', [
+                'The 1 must be a valid email address.',
+            ]);
+
+            $this->assertEquals([
+                [
+                    'There was an error on row 2. The 1 must be a valid email address.',
+                ],
+            ], $e->errors());
+        }
+
+        $this->assertInstanceOf(ValidationException::class, $e ?? null);
+    }
+
+    /**
+     * @test
+     */
+    public function can_prepare_using_tocollection()
+    {
+        $import = new class implements ToCollection, WithValidation {
+            use Importable;
+
+            /**
+             * @return array
+             */
+            public function rules(): array
+            {
+                return [
+                    '1' => 'email',
+                ];
+            }
+
+            /**
+             * Prepare the data for validation.
+             *
+             * @param array $row
+             * @param int $index
+             * @return array
+             */
+            public function prepareForValidation(array $row, int $index)
+            {
+                if ($index === 2) {
+                    $row[1] = 'not an email';
+                }
+
+                return $row;
+            }
+
+            /**
+             * @param \Illuminate\Support\Collection $collection
+             * @return mixed
+             */
+            public function collection(Collection $collection)
+            {
+                return collect();
+            }
+        };
+
+        try {
+            $import->import('import-users.xlsx');
+        } catch (ValidationException $e) {
+            $this->validateFailure($e, 2, '1', [
+                'The 1 must be a valid email address.',
+            ]);
+
+            $this->assertEquals([
+                [
+                    'There was an error on row 2. The 1 must be a valid email address.',
+                ],
+            ], $e->errors());
+        }
+
+        $this->assertInstanceOf(ValidationException::class, $e ?? null);
+    }
+
+    /**
+     * @test
+     */
+    public function can_prepare_using_tomodel()
+    {
+        $import = new class implements ToModel, WithValidation {
+            use Importable;
+
+            /**
+             * @return array
+             */
+            public function rules(): array
+            {
+                return [
+                    '1' => 'email',
+                ];
+            }
+
+            /**
+             * Prepare the data for validation.
+             *
+             * @param array $row
+             * @param int $index
+             * @return array
+             */
+            public function prepareForValidation(array $row, int $index)
+            {
+                if ($index === 2) {
+                    $row[1] = 'not an email';
+                }
+
+                return $row;
+            }
+
+            /**
+             * @param array $row
+             * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Model[]|null
+             */
+            public function model(array $row)
+            {
+                return new User([
+                    'name' => $row[0],
+                    'email' => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+        };
+
+        try {
+            $import->import('import-users.xlsx');
+        } catch (ValidationException $e) {
+            $this->validateFailure($e, 2, '1', [
+                'The 1 must be a valid email address.',
+            ]);
+
+            $this->assertEquals([
+                [
+                    'There was an error on row 2. The 1 must be a valid email address.',
+                ],
+            ], $e->errors());
+        }
+
+        $this->assertInstanceOf(ValidationException::class, $e ?? null);
+    }
+
+    /**
      * @param ValidationException $e
      * @param int                 $row
      * @param string              $attribute


### PR DESCRIPTION
### Requirements

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Updated CHANGELOG.md
* [x] Added tests to ensure against regression.

### Description of the Change

This PR allows imports implementing `WithValidation` to define a `prepareForValidation` method which can be used to manipulate incoming date _before_ it reaches the validator.

This can be useful in a number of situations where input may not directly pass validation but can still be parsed or converted to valid input.

### Why Should This Be Added?

There are multiple feature requests asking for this, as well as some issues where this PR could solve the problem.

### Benefits
Imports can now utilize logic to prepare data before validation, similar to Laravel's `FormRequest`

### Possible Drawbacks

None that I am aware of

### Verification Process

- Added tests manipulating import data using `prepareForValidation` in combination with `ToArray`, `ToCollection`, `ToModel` and `OnEachRow`
- Tested using `prepareForValidation` with `OnEachRow` on an existing real world import

### Applicable Issues
#2805 
#2115
#2120
