### PR TITLE
Catch exceptions for QueueExport job from package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added an ability to prepare rows before appending rows to sheet. Just add `prepareRows` method for your export class if needed.
+- Added ab ability to catch exceptions from `QueueExport` job. Just add `failed` method for your export class if needed.
 
 ## [3.1.24] - 2020-10-28
 

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Writer;
+use Throwable;
 
 class QueueExport implements ShouldQueue
 {
@@ -71,5 +72,15 @@ class QueueExport implements ShouldQueue
 
         // Write to temp file with empty sheets.
         $writer->write($sheetExport, $this->temporaryFile, $this->writerType);
+    }
+
+    /**
+     * @param Throwable $e
+     */
+    public function failed(Throwable $e)
+    {
+        if (method_exists($this->export, 'failed')) {
+            $this->export->failed($e);
+        }
     }
 }

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -2,11 +2,11 @@
 
 namespace Maatwebsite\Excel\Jobs;
 
+use Maatwebsite\Excel\Writer;
+use Maatwebsite\Excel\Files\TemporaryFile;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
-use Maatwebsite\Excel\Files\TemporaryFile;
-use Maatwebsite\Excel\Writer;
 use Throwable;
 
 class QueueExport implements ShouldQueue
@@ -16,7 +16,7 @@ class QueueExport implements ShouldQueue
     /**
      * @var object
      */
-    public $export;
+    private $export;
 
     /**
      * @var string
@@ -38,16 +38,6 @@ class QueueExport implements ShouldQueue
         $this->export        = $export;
         $this->writerType    = $writerType;
         $this->temporaryFile = $temporaryFile;
-    }
-
-    /**
-     * Get the middleware the job should be dispatched through.
-     *
-     * @return array
-     */
-    public function middleware()
-    {
-        return (method_exists($this->export, 'middleware')) ? $this->export->middleware() : [];
     }
 
     /**

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -2,11 +2,11 @@
 
 namespace Maatwebsite\Excel\Jobs;
 
-use Maatwebsite\Excel\Writer;
-use Maatwebsite\Excel\Files\TemporaryFile;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Files\TemporaryFile;
+use Maatwebsite\Excel\Writer;
 use Throwable;
 
 class QueueExport implements ShouldQueue
@@ -16,7 +16,7 @@ class QueueExport implements ShouldQueue
     /**
      * @var object
      */
-    private $export;
+    public $export;
 
     /**
      * @var string
@@ -38,6 +38,16 @@ class QueueExport implements ShouldQueue
         $this->export        = $export;
         $this->writerType    = $writerType;
         $this->temporaryFile = $temporaryFile;
+    }
+
+    /**
+     * Get the middleware the job should be dispatched through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return (method_exists($this->export, 'middleware')) ? $this->export->middleware() : [];
     }
 
     /**

--- a/tests/Data/Stubs/QueuedExportWithFailedEvents.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedEvents.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Exception;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Events\BeforeExport;
+use PHPUnit\Framework\Assert;
+use Throwable;
+
+class QueuedExportWithFailedEvents implements WithMultipleSheets, WithEvents
+{
+    use Exportable;
+
+    /**
+     * @return SheetWith100Rows[]
+     */
+    public function sheets(): array
+    {
+        return [
+            new SheetWith100Rows('A'),
+            new SheetWith100Rows('B'),
+            new SheetWith100Rows('C'),
+        ];
+    }
+
+    /**
+     * @param Throwable $exception
+     */
+    public function failed(Throwable $exception)
+    {
+        Assert::assertEquals('catch exception from QueueExport job', $exception->getMessage());
+
+        app()->bind('queue-has-failed-from-queue-export-job', function () {
+            return true;
+        });
+    }
+
+    /**
+     * @return array
+     */
+    public function registerEvents(): array
+    {
+        return [
+            BeforeExport::class => function () {
+                throw new Exception('catch exception from QueueExport job');
+            },
+        ];
+    }
+}

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -9,6 +9,7 @@ use Maatwebsite\Excel\Files\RemoteTemporaryFile;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Jobs\AppendDataToSheet;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedEvents;
 use Maatwebsite\Excel\Tests\Data\Stubs\EloquentCollectionWithMappingExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedHook;
@@ -141,5 +142,20 @@ class QueuedExportTest extends TestCase
         }
 
         $this->assertTrue(app('queue-has-failed'));
+    }
+
+    /**
+     * @test
+     */
+    public function can_catch_failures_on_queue_export_job()
+    {
+        $export = new QueuedExportWithFailedEvents();
+
+        try {
+            $export->queue('queued-export.xlsx');
+        } catch (Throwable $e) {
+        }
+
+        $this->assertTrue(app('queue-has-failed-from-queue-export-job'));
     }
 }


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [x] Updated CHANGELOG.md
* [x] Added tests to ensure against regression.

### Description of the Change

This PR allow users to catch exceptions from initial `QueueExport` job which is used as first job for chaining in the queued export.

### Why Should This Be Added?

This PR allow users to catch exceptions from initial `QueueExport` job which is used as first job for chaining in the queued export.

### Benefits

Catch and handle more exceptions.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts (e.g. breaking changes) of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

-->

### Applicable Issues

https://github.com/Maatwebsite/Laravel-Excel/issues/2899