### PR TITLE
[3.1] Use fully doc block path for Excel facade

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -2,9 +2,6 @@
 
 namespace Maatwebsite\Excel;
 
-use Illuminate\Foundation\Bus\PendingDispatch;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
-
 interface Exporter
 {
     /**
@@ -15,7 +12,7 @@ interface Exporter
      *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
-     * @return BinaryFileResponse
+     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
     public function download($export, string $fileName, string $writerType = null, array $headers = []);
 
@@ -39,7 +36,7 @@ interface Exporter
      * @param string      $writerType
      * @param mixed       $diskOptions
      *
-     * @return PendingDispatch
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
     public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = []);
 

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -3,25 +3,23 @@
 namespace Maatwebsite\Excel;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 interface Importer
 {
     /**
      * @param object              $import
-     * @param string|UploadedFile $filePath
+     * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $filePath
      * @param string|null         $disk
      * @param string|null         $readerType
      *
-     * @return Reader|PendingDispatch
+     * @return Reader|\Illuminate\Foundation\Bus\PendingDispatch
      */
     public function import($import, $filePath, string $disk = null, string $readerType = null);
 
     /**
      * @param object              $import
-     * @param string|UploadedFile $filePath
+     * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $filePath
      * @param string|null         $disk
      * @param string|null         $readerType
      *
@@ -31,7 +29,7 @@ interface Importer
 
     /**
      * @param object              $import
-     * @param string|UploadedFile $filePath
+     * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $filePath
      * @param string|null         $disk
      * @param string|null         $readerType
      *
@@ -41,11 +39,11 @@ interface Importer
 
     /**
      * @param ShouldQueue         $import
-     * @param string|UploadedFile $filePath
+     * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $filePath
      * @param string|null         $disk
      * @param string              $readerType
      *
-     * @return PendingDispatch
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
     public function queueImport(ShouldQueue $import, $filePath, string $disk = null, string $readerType = null);
 }


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Updated CHANGELOG.md
* [ ] Added tests to ensure against regression.

### Description of the Change

Added fully path for Doc Block comment.

### Why Should This Be Added?

Because ide-helper generate types by comments and right now the comments incorrect.

![Screenshot from 2020-11-04 13-25-50](https://user-images.githubusercontent.com/7753600/98100104-76679580-1ea1-11eb-93b2-d2fd1b37d7f1.png)

![Screenshot from 2020-11-04 13-29-06](https://user-images.githubusercontent.com/7753600/98100328-c2b2d580-1ea1-11eb-830c-85697c1f4743.png)


<!-- Explain why this functionality should be added in Laravel-Excel -->

### Benefits

Correct highlight in the IDE.
