### PR TITLE
[3.1] Add support to upsert models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Added an ability to catch exceptions from `QueueExport` job. Just add `failed` method for your export class if needed.
 - Added an ability to set locale for queued export. Just implement `Illuminate\Contracts\Translation\HasLocalePreference` for your export.
 - Added `JsonSerializable` support in `Maatwebsite\Excel\Validators\Failure`.
+- Added support to upsert models by implementing the `WithUpserts` concern.
 
 ## [3.1.24] - 2020-10-28
 

--- a/src/Concerns/WithUpserts.php
+++ b/src/Concerns/WithUpserts.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithUpserts
+{
+    /**
+     * @return string|array
+     */
+    public function uniqueBy();
+}

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -114,8 +114,8 @@ class ModelManager
                      if ($import instanceof WithUpserts) {
                          $model::query()->upsert($models->toArray(), $import->uniqueBy());
                      } else {
-                        /* @var Model $model */
-                        $model::query()->insert($models->toArray());
+                         /* @var Model $model */
+                         $model::query()->insert($models->toArray());
                      }
                  } catch (Throwable $e) {
                      if ($import instanceof SkipsOnError) {

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\SkipsOnError;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithUpserts;
 use Maatwebsite\Excel\Concerns\WithValidation;
 use Maatwebsite\Excel\Exceptions\RowSkippedException;
 use Maatwebsite\Excel\Validators\RowValidator;
@@ -110,8 +111,12 @@ class ModelManager
              })
              ->each(function (Collection $models, string $model) use ($import) {
                  try {
-                     /* @var Model $model */
-                     $model::query()->insert($models->toArray());
+                     if ($import instanceof WithUpserts) {
+                         $model::query()->upsert($models->toArray(), $import->uniqueBy());
+                     } else {
+                        /* @var Model $model */
+                        $model::query()->insert($models->toArray());
+                     }
                  } catch (Throwable $e) {
                      if ($import instanceof SkipsOnError) {
                          $import->onError($e);
@@ -132,7 +137,11 @@ class ModelManager
             ->each(function (array $attributes, $index) use ($import) {
                 $this->toModels($import, $attributes, $index)->each(function (Model $model) use ($import) {
                     try {
-                        $model->saveOrFail();
+                        if ($import instanceof WithUpserts) {
+                            $model->upsert($model->getAttributes(), $import->uniqueBy());
+                        } else {
+                            $model->saveOrFail();
+                        }
                     } catch (Throwable $e) {
                         if ($import instanceof SkipsOnError) {
                             $import->onError($e);

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -8,7 +8,6 @@ use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithUpserts;
-use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\TestCase;
 
@@ -29,7 +28,7 @@ class WithUpsertsTest extends TestCase
      */
     public function can_upsert_models_in_batches()
     {
-        User::create( [
+        User::create([
             'name'      => 'Funny Banana',
             'email'     => 'patrick@maatwebsite.nl',
             'password'  => 'password',
@@ -94,7 +93,7 @@ class WithUpsertsTest extends TestCase
      */
     public function can_upsert_models_in_rows()
     {
-        User::create( [
+        User::create([
             'name'      => 'Funny Potato',
             'email'     => 'patrick@maatwebsite.nl',
             'password'  => 'password',

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -19,10 +19,10 @@ class WithUpsertsTest extends TestCase
      */
     protected function setUp(): void
     {
-        if (! method_exists(Builder::class, 'upsert')) {
+        if (!method_exists(Builder::class, 'upsert')) {
             $this->markTestSkipped('The upsert feature is available on Laravel 8.10+');
         }
-        
+
         parent::setUp();
 
         $this->loadLaravelMigrations(['--database' => 'testing']);

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Concerns\Importable;
@@ -18,6 +19,10 @@ class WithUpsertsTest extends TestCase
      */
     protected function setUp(): void
     {
+        if (! method_exists(Builder::class, 'upsert')) {
+            $this->markTestSkipped('The upsert feature is available on Laravel 8.10+');
+        }
+        
         parent::setUp();
 
         $this->loadLaravelMigrations(['--database' => 'testing']);

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithBatchInserts;
+use Maatwebsite\Excel\Concerns\WithUpserts;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use Maatwebsite\Excel\Tests\TestCase;
+
+class WithUpsertsTest extends TestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadLaravelMigrations(['--database' => 'testing']);
+    }
+
+    /**
+     * @test
+     */
+    public function can_upsert_models_in_batches()
+    {
+        User::create( [
+            'name'      => 'Funny Banana',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
+        ]);
+
+        DB::connection()->enableQueryLog();
+
+        $import = new class implements ToModel, WithBatchInserts, WithUpserts {
+            use Importable;
+
+            /**
+             * @param array $row
+             *
+             * @return Model|null
+             */
+            public function model(array $row)
+            {
+                return new User([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @return string|array
+             */
+            public function uniqueBy()
+            {
+                return 'email';
+            }
+
+            /**
+             * @return int
+             */
+            public function batchSize(): int
+            {
+                return 2;
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(1, DB::getQueryLog());
+        DB::connection()->disableQueryLog();
+
+        $this->assertDatabaseHas('users', [
+            'name'  => 'Patrick Brouwers',
+            'email' => 'patrick@maatwebsite.nl',
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'name'  => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $this->assertEquals(2, User::count());
+    }
+
+    /**
+     * @test
+     */
+    public function can_upsert_models_in_rows()
+    {
+        User::create( [
+            'name'      => 'Funny Potato',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
+        ]);
+
+        DB::connection()->enableQueryLog();
+
+        $import = new class implements ToModel, WithUpserts {
+            use Importable;
+
+            /**
+             * @param array $row
+             *
+             * @return Model|Model[]|null
+             */
+            public function model(array $row)
+            {
+                return new User([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @return string|array
+             */
+            public function uniqueBy()
+            {
+                return 'email';
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(2, DB::getQueryLog());
+        DB::connection()->disableQueryLog();
+
+        $this->assertDatabaseHas('users', [
+            'name'  => 'Patrick Brouwers',
+            'email' => 'patrick@maatwebsite.nl',
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'name'  => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $this->assertEquals(2, User::count());
+    }
+}


### PR DESCRIPTION
Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Updated CHANGELOG.md
* [x] Added tests to ensure against regression.

### Description of the Change

This PR adds the ability to upsert (available since Laravel 8.10) while importing. Currently, only inserts are supported. To use this feature, we just need to implement the `WithUpserts` interface like so:

```php
class UsersImport implements ToModel, WithUpserts
{
    public function model(array $row)
    {
        return new User([
            'name' => $row[0],
        ]);
    }

    public function uniqueBy()
    {
        return 'email';
    }
}
```

### Why Should This Be Added?

I think it would be quite a common use case to import files as upserts instead of inserts.

### Benefits

Would allow users to import files as upserts.

### Possible Drawbacks

No breaking changes or drawbacks.

### Verification Process

Verified all tests are good and also added new tests for the feature.
