### PR TITLE
Fixing bug found in discussion #2987

### DIFF
--- a/src/Validators/RowValidator.php
+++ b/src/Validators/RowValidator.php
@@ -56,7 +56,7 @@ class RowValidator
                     $row,
                     $attributeName,
                     str_replace($attribute, $attributeName, $messages),
-                    $rows[$row]
+                    $rows[$row] ?? []
                 );
             }
 


### PR DESCRIPTION
### Requirements

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Updated CHANGELOG.md
* [ ] Added tests to ensure against regression.

### Description of the Change

When you use the withValidator() method and call the $validator->errors()->add() method to generate a custom error as instructed in the documentation, if the error doesn't exists from a previous validation, it will raise an `Undefined index` exception. This small fix solves the problem as suggested by @patrickbrouwers .

### Why Should This Be Added?

Fixes an exception when adding new errors to the validator

### Benefits

You can add new errors to the validator

### Possible Drawbacks

No tests

### Verification Process

Test on local machine

### Applicable Issues

Discussion #2987
