### PR TITLE
make progress bar redirect to nullOutput if not provided

### DIFF
--- a/src/Concerns/Importable.php
+++ b/src/Concerns/Importable.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Maatwebsite\Excel\Exceptions\NoFilePathGivenException;
 use Maatwebsite\Excel\Importer;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait Importable
@@ -114,9 +116,7 @@ trait Importable
     public function getConsoleOutput(): OutputStyle
     {
         if (!$this->output instanceof OutputStyle) {
-            throw new InvalidArgumentException(
-                'Importable has no OutputStyle. Declare one by using ->withOutput($this->output).'
-            );
+            $this->output = new OutputStyle(new StringInput(''), new NullOutput());
         }
 
         return $this->output;


### PR DESCRIPTION
return nullOutput if not set instead of throwing error to use method `->withOutput()` because sometimes I need to call the excel from `Action` as a (command) or as a (job, object) and the current implementation make it mandatory to pass the `OutputStype` class even if I run it as a job

![image](https://user-images.githubusercontent.com/29691074/108136941-a428c100-70c3-11eb-9b34-ffa470554020.png)
