### PR TITLE
Define upsert columns

### DIFF
--- a/src/Concerns/WithUpsertColumns.php
+++ b/src/Concerns/WithUpsertColumns.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithUpsertColumns
+{
+    /**
+     * @return array
+     */
+    public function upsertColumns();
+}

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\SkipsOnError;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithUpsertColumns;
 use Maatwebsite\Excel\Concerns\WithUpserts;
 use Maatwebsite\Excel\Concerns\WithValidation;
 use Maatwebsite\Excel\Exceptions\RowSkippedException;
@@ -111,10 +112,15 @@ class ModelManager
              })
              ->each(function (Collection $models, string $model) use ($import) {
                  try {
+                     /* @var Model $model */
+
                      if ($import instanceof WithUpserts) {
-                         $model::query()->upsert($models->toArray(), $import->uniqueBy());
+                         $model::query()->upsert(
+                             $models->toArray(),
+                             $import->uniqueBy(),
+                             $import instanceof WithUpsertColumns ? $import->upsertColumns() : null
+                         );
                      } else {
-                         /* @var Model $model */
                          $model::query()->insert($models->toArray());
                      }
                  } catch (Throwable $e) {
@@ -138,7 +144,11 @@ class ModelManager
                 $this->toModels($import, $attributes, $index)->each(function (Model $model) use ($import) {
                     try {
                         if ($import instanceof WithUpserts) {
-                            $model->upsert($model->getAttributes(), $import->uniqueBy());
+                            $model->upsert(
+                                $model->getAttributes(),
+                                $import->uniqueBy(),
+                                $import instanceof WithUpsertColumns ? $import->upsertColumns() : null
+                            );
                         } else {
                             $model->saveOrFail();
                         }

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
+use Maatwebsite\Excel\Concerns\WithUpsertColumns;
 use Maatwebsite\Excel\Concerns\WithUpserts;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\TestCase;
@@ -83,11 +84,13 @@ class WithUpsertsTest extends TestCase
         $this->assertDatabaseHas('users', [
             'name'  => 'Patrick Brouwers',
             'email' => 'patrick@maatwebsite.nl',
+            'password' => 'secret',
         ]);
 
         $this->assertDatabaseHas('users', [
             'name'  => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
+            'password' => 'secret',
         ]);
 
         $this->assertEquals(2, User::count());
@@ -140,11 +143,155 @@ class WithUpsertsTest extends TestCase
         $this->assertDatabaseHas('users', [
             'name'  => 'Patrick Brouwers',
             'email' => 'patrick@maatwebsite.nl',
+            'password' => 'secret',
         ]);
 
         $this->assertDatabaseHas('users', [
             'name'  => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $this->assertEquals(2, User::count());
+    }
+
+    /**
+     * @test
+     */
+    public function can_upsert_models_in_batches_with_defined_upsert_columns()
+    {
+        User::create([
+            'name'      => 'Funny Banana',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
+        ]);
+
+        DB::connection()->enableQueryLog();
+
+        $import = new class implements ToModel, WithBatchInserts, WithUpserts, WithUpsertColumns {
+            use Importable;
+
+            /**
+             * @param array $row
+             *
+             * @return Model|null
+             */
+            public function model(array $row)
+            {
+                return new User([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @return string|array
+             */
+            public function uniqueBy()
+            {
+                return 'email';
+            }
+
+            /**
+             * @return array
+             */
+            public function upsertColumns()
+            {
+                return ['name'];
+            }
+
+            /**
+             * @return int
+             */
+            public function batchSize(): int
+            {
+                return 2;
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(1, DB::getQueryLog());
+        DB::connection()->disableQueryLog();
+
+        $this->assertDatabaseHas('users', [
+            'name'  => 'Patrick Brouwers',
+            'email' => 'patrick@maatwebsite.nl',
+            'password' => 'password',
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'name'  => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $this->assertEquals(2, User::count());
+    }
+
+    /**
+     * @test
+     */
+    public function can_upsert_models_in_rows_with_defined_upsert_columns()
+    {
+        User::create([
+            'name'      => 'Funny Potato',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
+        ]);
+
+        DB::connection()->enableQueryLog();
+
+        $import = new class implements ToModel, WithUpserts, WithUpsertColumns {
+            use Importable;
+
+            /**
+             * @param array $row
+             *
+             * @return Model|Model[]|null
+             */
+            public function model(array $row)
+            {
+                return new User([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @return string|array
+             */
+            public function uniqueBy()
+            {
+                return 'email';
+            }
+
+            /**
+             * @return array
+             */
+            public function upsertColumns()
+            {
+                return ['name'];
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(2, DB::getQueryLog());
+        DB::connection()->disableQueryLog();
+
+        $this->assertDatabaseHas('users', [
+            'name'  => 'Patrick Brouwers',
+            'email' => 'patrick@maatwebsite.nl',
+            'password' => 'password',
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'name'  => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
         ]);
 
         $this->assertEquals(2, User::count());

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -82,15 +82,15 @@ class WithUpsertsTest extends TestCase
         DB::connection()->disableQueryLog();
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Patrick Brouwers',
-            'email' => 'patrick@maatwebsite.nl',
-            'password' => 'secret',
+            'name'      => 'Patrick Brouwers',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'secret',
         ]);
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Taylor Otwell',
-            'email' => 'taylor@laravel.com',
-            'password' => 'secret',
+            'name'      => 'Taylor Otwell',
+            'email'     => 'taylor@laravel.com',
+            'password'  => 'secret',
         ]);
 
         $this->assertEquals(2, User::count());
@@ -141,15 +141,15 @@ class WithUpsertsTest extends TestCase
         DB::connection()->disableQueryLog();
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Patrick Brouwers',
-            'email' => 'patrick@maatwebsite.nl',
-            'password' => 'secret',
+            'name'      => 'Patrick Brouwers',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'secret',
         ]);
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Taylor Otwell',
-            'email' => 'taylor@laravel.com',
-            'password' => 'secret',
+            'name'      => 'Taylor Otwell',
+            'email'     => 'taylor@laravel.com',
+            'password'  => 'secret',
         ]);
 
         $this->assertEquals(2, User::count());
@@ -216,15 +216,15 @@ class WithUpsertsTest extends TestCase
         DB::connection()->disableQueryLog();
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Patrick Brouwers',
-            'email' => 'patrick@maatwebsite.nl',
-            'password' => 'password',
+            'name'      => 'Patrick Brouwers',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
         ]);
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Taylor Otwell',
-            'email' => 'taylor@laravel.com',
-            'password' => 'secret',
+            'name'      => 'Taylor Otwell',
+            'email'     => 'taylor@laravel.com',
+            'password'  => 'secret',
         ]);
 
         $this->assertEquals(2, User::count());
@@ -283,15 +283,15 @@ class WithUpsertsTest extends TestCase
         DB::connection()->disableQueryLog();
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Patrick Brouwers',
-            'email' => 'patrick@maatwebsite.nl',
-            'password' => 'password',
+            'name'      => 'Patrick Brouwers',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
         ]);
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Taylor Otwell',
-            'email' => 'taylor@laravel.com',
-            'password' => 'secret',
+            'name'      => 'Taylor Otwell',
+            'email'     => 'taylor@laravel.com',
+            'password'  => 'secret',
         ]);
 
         $this->assertEquals(2, User::count());


### PR DESCRIPTION
1️⃣ Why should it be added? What are the benefits of this change?

This PR adds the ability to setup/configure the list columns that should be updated when using `upsert` functionality. Right now, `WithUpserts` will update all columns (based on the model's filled attributes) which can be troublesome in some cases. Especially, if you want to use `ToModel` interface as well as batch inserts.

Example: I'm importing a set of work orders and using UUID as an identifier. Import file does not have any identifier information (and obviously, I want to preserve UUIDs between imports). During import, I need to instantiate the model and fill it with data from the import, but also generate a UUID.:
```php
    public function model(array $row): Model
    {
        return new WorkOrder([
            'id' => Str::orderedUuid()->toString(),
            'code' => trim($row[0])
        ]);
    }
```
`code` is upsert unique (I know that I can set an array of uniques, but this example is just to show that things can be improved). 
Using current upsert functionality, `id` column will be updated, which is undesirable.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible?

Yes.

4️⃣ Any drawbacks? Possible breaking changes?

No. In order to avoid such changes, I've introduced a separate interface `WithUpsertColumns` that allows specifying a list of columns for upsert.

Of course, my "naming" proposition or code style is subject to discussion/change. I'll be happy to adjust it if needed.