### PR TITLE
Hotfix/before write firing only once

### DIFF
--- a/src/Concerns/RegistersEventListeners.php
+++ b/src/Concerns/RegistersEventListeners.php
@@ -2,13 +2,14 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
-use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\AfterSheet;
+use Maatwebsite\Excel\Events\AfterImport;
+use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Events\BeforeExport;
 use Maatwebsite\Excel\Events\BeforeImport;
-use Maatwebsite\Excel\Events\BeforeSheet;
-use Maatwebsite\Excel\Events\BeforeWriting;
 use Maatwebsite\Excel\Events\ImportFailed;
+use Maatwebsite\Excel\Events\BeforeWriting;
+use Maatwebsite\Excel\Events\BeforeChunkWriting;
 
 trait RegistersEventListeners
 {
@@ -25,6 +26,10 @@ trait RegistersEventListeners
 
         if (method_exists($this, 'beforeWriting')) {
             $listeners[BeforeWriting::class] = [static::class, 'beforeWriting'];
+        }
+
+        if (method_exists($this, 'beforeChunkWriting')) {
+            $listeners[BeforeChunkWriting::class] = [static::class, 'beforeChunkWriting'];
         }
 
         if (method_exists($this, 'beforeImport')) {

--- a/src/Concerns/RegistersEventListeners.php
+++ b/src/Concerns/RegistersEventListeners.php
@@ -2,14 +2,14 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
-use Maatwebsite\Excel\Events\AfterSheet;
 use Maatwebsite\Excel\Events\AfterImport;
-use Maatwebsite\Excel\Events\BeforeSheet;
+use Maatwebsite\Excel\Events\AfterSheet;
+use Maatwebsite\Excel\Events\BeforeChunkWriting;
 use Maatwebsite\Excel\Events\BeforeExport;
 use Maatwebsite\Excel\Events\BeforeImport;
-use Maatwebsite\Excel\Events\ImportFailed;
+use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Events\BeforeWriting;
-use Maatwebsite\Excel\Events\BeforeChunkWriting;
+use Maatwebsite\Excel\Events\ImportFailed;
 
 trait RegistersEventListeners
 {

--- a/src/Events/BeforeChunkWriting.php
+++ b/src/Events/BeforeChunkWriting.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Maatwebsite\Excel\Events;
+
+use Maatwebsite\Excel\Writer;
+
+class BeforeChunkWriting extends Event
+{
+    /**
+     * @var Writer
+     */
+    public $writer;
+
+    /**
+     * @var object
+     */
+    private $exportable;
+
+    /**
+     * @param Writer $writer
+     * @param object $exportable
+     */
+    public function __construct(Writer $writer, $exportable)
+    {
+        $this->writer     = $writer;
+        $this->exportable = $exportable;
+    }
+
+    /**
+     * @return Writer
+     */
+    public function getWriter(): Writer
+    {
+        return $this->writer;
+    }
+
+    /**
+     * @return object
+     */
+    public function getConcernable()
+    {
+        return $this->exportable;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDelegate()
+    {
+        return $this->writer;
+    }
+}

--- a/src/ExcelServiceProvider.php
+++ b/src/ExcelServiceProvider.php
@@ -86,6 +86,10 @@ class ExcelServiceProvider extends ServiceProvider
             return new Filesystem($this->app->make('filesystem'));
         });
 
+        $this->app->singleton(Writer::class, function ($app) {
+            return new Writer($app->make(TemporaryFileFactory::class));
+        });
+
         $this->app->bind('excel', function () {
             return new Excel(
                 $this->app->make(Writer::class),

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -72,6 +72,8 @@ class QueueExport implements ShouldQueue
                 $sheet->open($sheetExport);
             }
 
+            $writer->raiseBeforeWritingEvent();
+
             // Write to temp file with empty sheets.
             $writer->write($sheetExport, $this->temporaryFile, $this->writerType);
         });

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -2,21 +2,22 @@
 
 namespace Maatwebsite\Excel;
 
-use Maatwebsite\Excel\Cache\CacheManager;
-use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
-use Maatwebsite\Excel\Concerns\WithEvents;
-use Maatwebsite\Excel\Concerns\WithMultipleSheets;
-use Maatwebsite\Excel\Concerns\WithProperties;
-use Maatwebsite\Excel\Concerns\WithTitle;
-use Maatwebsite\Excel\Events\BeforeExport;
-use Maatwebsite\Excel\Events\BeforeWriting;
-use Maatwebsite\Excel\Factories\WriterFactory;
-use Maatwebsite\Excel\Files\RemoteTemporaryFile;
-use Maatwebsite\Excel\Files\TemporaryFile;
-use Maatwebsite\Excel\Files\TemporaryFileFactory;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use Maatwebsite\Excel\Cache\CacheManager;
+use Maatwebsite\Excel\Concerns\WithTitle;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\BeforeExport;
+use Maatwebsite\Excel\Files\TemporaryFile;
+use Maatwebsite\Excel\Events\BeforeWriting;
+use Maatwebsite\Excel\Concerns\WithProperties;
+use Maatwebsite\Excel\Factories\WriterFactory;
+use Maatwebsite\Excel\Events\BeforeChunkWriting;
+use Maatwebsite\Excel\Files\RemoteTemporaryFile;
+use Maatwebsite\Excel\Files\TemporaryFileFactory;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 
 class Writer
 {
@@ -130,7 +131,7 @@ class Writer
 
         $this->spreadsheet->setActiveSheetIndex(0);
 
-        $this->raise(new BeforeWriting($this, $this->exportable));
+        $this->raise(new BeforeChunkWriting($this, $this->exportable));
 
         $writer = WriterFactory::make(
             $writerType,

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -79,7 +79,7 @@ class Writer
     {
         $this->exportable = $export;
 
-        if ($export instanceof WithEvents) {
+        if ($export instanceof WithEvents && !count($this->events)) {
             $this->registerListeners($export->registerEvents());
         }
 

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -79,7 +79,9 @@ class Writer
     {
         $this->exportable = $export;
 
-        if ($export instanceof WithEvents && !count($this->events)) {
+        $this->clearListeners();
+        
+        if ($export instanceof WithEvents) {
             $this->registerListeners($export->registerEvents());
         }
 

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -2,22 +2,22 @@
 
 namespace Maatwebsite\Excel;
 
+use Maatwebsite\Excel\Cache\CacheManager;
+use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Concerns\WithProperties;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use Maatwebsite\Excel\Events\BeforeChunkWriting;
+use Maatwebsite\Excel\Events\BeforeExport;
+use Maatwebsite\Excel\Events\BeforeWriting;
+use Maatwebsite\Excel\Factories\WriterFactory;
+use Maatwebsite\Excel\Files\RemoteTemporaryFile;
+use Maatwebsite\Excel\Files\TemporaryFile;
+use Maatwebsite\Excel\Files\TemporaryFileFactory;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\IOFactory;
-use Maatwebsite\Excel\Cache\CacheManager;
-use Maatwebsite\Excel\Concerns\WithTitle;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use Maatwebsite\Excel\Concerns\WithEvents;
-use Maatwebsite\Excel\Events\BeforeExport;
-use Maatwebsite\Excel\Files\TemporaryFile;
-use Maatwebsite\Excel\Events\BeforeWriting;
-use Maatwebsite\Excel\Concerns\WithProperties;
-use Maatwebsite\Excel\Factories\WriterFactory;
-use Maatwebsite\Excel\Events\BeforeChunkWriting;
-use Maatwebsite\Excel\Files\RemoteTemporaryFile;
-use Maatwebsite\Excel\Files\TemporaryFileFactory;
-use Maatwebsite\Excel\Concerns\WithMultipleSheets;
-use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 
 class Writer
 {
@@ -83,7 +83,7 @@ class Writer
         $this->exportable = $export;
 
         $this->clearListeners();
-        
+
         if ($export instanceof WithEvents) {
             $this->registerListeners($export->registerEvents());
         }
@@ -208,7 +208,7 @@ class Writer
         return $this->exportable instanceof $concern;
     }
 
-     /**
+    /**
      * @return void
      */
     public function raiseBeforeWritingEvent(): void

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -68,6 +68,8 @@ class Writer
             $this->addNewSheet()->export($sheetExport);
         }
 
+        $this->raiseBeforeWritingEvent();
+
         return $this->write($export, $this->temporaryFileFactory->makeLocal(null, strtolower($writerType)), $writerType);
     }
 
@@ -204,6 +206,14 @@ class Writer
     public function hasConcern($concern): bool
     {
         return $this->exportable instanceof $concern;
+    }
+
+     /**
+     * @return void
+     */
+    public function raiseBeforeWritingEvent(): void
+    {
+        $this->raise(new BeforeWriting($this, $this->exportable));
     }
 
     /**


### PR DESCRIPTION
1️⃣ Why should it be added? What are the benefits of this change?
It can be used to implement progress bars for chunked exports. We could update the progress of the export each time the BeforeChunkWriting "listener" is being called.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, it doesn't.

3️⃣ Does it include tests, if possible?
No, it doesn't include tests.

4️⃣ Any drawbacks? Possible breaking changes?
Can't really think of any.  Please feel free to point out if you think it can cause issues.

Please feel free to comment on the changes if you don't find them adequate,  I will take care of making the appropriate changes.

