### PR TITLE
Custom heading row formatter can use column index.

### DIFF
--- a/src/Imports/HeadingRowFormatter.php
+++ b/src/Imports/HeadingRowFormatter.php
@@ -43,8 +43,8 @@ class HeadingRowFormatter
      */
     public static function format(array $headings): array
     {
-        return (new Collection($headings))->map(function ($value) {
-            return static::callFormatter($value);
+        return (new Collection($headings))->map(function ($value, $key) {
+            return static::callFormatter($value, $key);
         })->toArray();
     }
 
@@ -82,7 +82,7 @@ class HeadingRowFormatter
      *
      * @return mixed
      */
-    protected static function callFormatter($value)
+    protected static function callFormatter($value, $key=null)
     {
         static::$formatter = static::$formatter ?? config('excel.imports.heading_row.formatter', self::FORMATTER_SLUG);
 
@@ -90,7 +90,7 @@ class HeadingRowFormatter
         if (isset(static::$customFormatters[static::$formatter])) {
             $formatter = static::$customFormatters[static::$formatter];
 
-            return $formatter($value);
+            return $formatter($value, $key);
         }
 
         if (static::$formatter === self::FORMATTER_SLUG) {

--- a/tests/HeadingRowImportTest.php
+++ b/tests/HeadingRowImportTest.php
@@ -53,6 +53,28 @@ class HeadingRowImportTest extends TestCase
     /**
      * @test
      */
+    public function can_import_only_heading_row_with_custom_heading_row_formatter_with_key()
+    {
+        HeadingRowFormatter::extend('custom', function ($value, $key) {
+            return $key;
+        });
+
+        HeadingRowFormatter::default('custom');
+
+        $import = new HeadingRowImport();
+
+        $headings = $import->toArray('import-users-with-headings.xlsx');
+
+        $this->assertEquals([
+            [
+                [0, 1],
+            ],
+        ], $headings);
+    }
+
+    /**
+     * @test
+     */
     public function can_import_only_heading_row_with_custom_row_number()
     {
         $import = new HeadingRowImport(2);
@@ -81,6 +103,31 @@ class HeadingRowImportTest extends TestCase
             ],
             [
                 ['2a1', '2b1'], // slugged first row of sheet 2
+            ],
+        ], $headings);
+    }
+
+
+    /**
+     * @test
+     */
+    public function can_import_only_heading_row_for_multiple_sheets_with_key()
+    {
+        HeadingRowFormatter::extend('custom', function ($value, $key) {
+            return $key;
+        });
+
+        HeadingRowFormatter::default('custom');
+        $import = new HeadingRowImport();
+
+        $headings = $import->toArray('import-multiple-sheets.xlsx');
+
+        $this->assertEquals([
+            [
+                [0, 1], // slugged first row of sheet 1
+            ],
+            [
+                [0, 1], // slugged first row of sheet 2
             ],
         ], $headings);
     }

--- a/tests/HeadingRowImportTest.php
+++ b/tests/HeadingRowImportTest.php
@@ -107,7 +107,6 @@ class HeadingRowImportTest extends TestCase
         ], $headings);
     }
 
-
     /**
      * @test
      */


### PR DESCRIPTION
1️⃣ Why should it be added? What are the benefits of this change?

If the Excel header contains long multi-byte text, it was inconvenient to not be able to use the header column index to use WithValidation while skipping the header.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

It's OK. 
I only edited 1 file and added 4 "$key".

3️⃣ Does it include tests, if possible?

Yes. I added 2 test case.
I compared the test results before and after the change. 
I confirmed that the only difference was whether the test cases I added were cleared or not.

4️⃣ Any drawbacks? Possible breaking changes?

Probably not.

5️⃣ Thanks for contributing! 🙌

Thank you for developing a great library.
The code was clean and very easy to read. I would like to learn from you.