### PR TITLE
Fix Bug #3127 Formulas are not calculated when import implements …

### DIFF
--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -60,7 +60,7 @@ class ModelImporter
             $i++;
 
             $row = new Row($spreadSheetRow, $headingRow);
-            if (!$import instanceof SkipsEmptyRows || ($import instanceof SkipsEmptyRows && !$row->isEmpty())) {
+            if (!$import instanceof SkipsEmptyRows || ($import instanceof SkipsEmptyRows && !$row->isEmpty($withCalcFormulas))) {
                 $rowArray = $row->toArray(null, $withCalcFormulas, $formatData, $endColumn);
 
                 if ($withValidation) {

--- a/src/Row.php
+++ b/src/Row.php
@@ -104,9 +104,9 @@ class Row implements ArrayAccess
     /**
      * @return bool
      */
-    public function isEmpty(): bool
+    public function isEmpty($calculateFormulas = false): bool
     {
-        return count(array_filter($this->toArray(null, false, false))) === 0;
+        return count(array_filter($this->toArray(null, $calculateFormulas, false))) === 0;
     }
 
     /**

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -293,7 +293,7 @@ class Sheet
             foreach ($this->worksheet->getRowIterator()->resetStart($startRow ?? 1) as $row) {
                 $sheetRow = new Row($row, $headingRow);
 
-                if (!$import instanceof SkipsEmptyRows || ($import instanceof SkipsEmptyRows && !$sheetRow->isEmpty())) {
+                if (!$import instanceof SkipsEmptyRows || ($import instanceof SkipsEmptyRows && !$sheetRow->isEmpty($calculatesFormulas))) {
                     if ($import instanceof WithValidation) {
                         $sheetRow->setPreparationCallback($preparationCallback);
                         $toValidate = [$sheetRow->getIndex() => $sheetRow->toArray(null, $import instanceof WithCalculatedFormulas, $import instanceof WithFormatData, $endColumn)];
@@ -344,7 +344,7 @@ class Sheet
         foreach ($this->worksheet->getRowIterator($startRow, $endRow) as $index => $row) {
             $row = new Row($row, $headingRow);
 
-            if ($import instanceof SkipsEmptyRows && $row->isEmpty()) {
+            if ($import instanceof SkipsEmptyRows && $row->isEmpty($calculateFormulas)) {
                 continue;
             }
 

--- a/tests/Concerns/WithCalculatedFormulasTest.php
+++ b/tests/Concerns/WithCalculatedFormulasTest.php
@@ -10,6 +10,7 @@ use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Concerns\WithStartRow;
+use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Tests\TestCase;
 use PHPUnit\Framework\Assert;
 
@@ -174,5 +175,63 @@ class WithCalculatedFormulasTest extends TestCase
         };
 
         $import->import('import-formulas-multiple-sheets.xlsx');
+    }
+
+    /**
+     * @test
+     */
+    public function can_import_to_array_with_calculated_formulas_and_skips_empty()
+    {
+        $import = new class implements ToArray, WithCalculatedFormulas, SkipsEmptyRows
+        {
+            use Importable;
+
+            public $called = false;
+
+            /**
+             * @param array $array
+             */
+            public function array(array $array)
+            {
+                $this->called = true;
+
+                Assert::assertSame(2, $array[0][0]);
+            }
+        };
+
+        $import->import('import-formulas.xlsx');
+
+        $this->assertTrue($import->called);
+    }
+
+    /**
+     * @test
+     */
+    public function can_import_to_model_with_calculated_formulas_and_skips_empty()
+    {
+        $import = new class implements ToModel, WithCalculatedFormulas, SkipsEmptyRows
+        {
+            use Importable;
+
+            public $called = false;
+
+            /**
+             * @param array $row
+             *
+             * @return Model|null
+             */
+            public function model(array $row)
+            {
+                $this->called = true;
+
+                Assert::assertSame(2, $row[0]);
+
+                return null;
+            }
+        };
+
+        $import->import('import-formulas.xlsx');
+
+        $this->assertTrue($import->called);
     }
 }

--- a/tests/Concerns/WithCalculatedFormulasTest.php
+++ b/tests/Concerns/WithCalculatedFormulasTest.php
@@ -5,12 +5,12 @@ namespace Maatwebsite\Excel\Tests\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\HasReferencesToOtherSheets;
 use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Concerns\WithStartRow;
-use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Tests\TestCase;
 use PHPUnit\Framework\Assert;
 


### PR DESCRIPTION
…WithCalculatedFormulas with SkipsEmptyRows 

1️⃣ Why should it be added? What are the benefits of this change?
isEmpty() calls toArray with calculatefarmusas always to false modifying the row object and affecting subsequent calls to toArray function .
The best  solution I found is to call it with the same value for $calculatefarmulas as subsequent calls to toArray.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, it doesn't.

3️⃣ Does it include tests, if possible?
Yes, two unit test for the following Concerns combination:
1. - ToArray, WithCalculatedFormulas, SkipsEmptyRows
2. - ToModel, WithCalculatedFormulas, SkipsEmptyRows

4️⃣ Any drawbacks? Possible breaking changes?
No, IMO.