### PR TITLE
Fix ChunkReader default name bug

### DIFF
--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -82,7 +82,11 @@ class ChunkReader
 
         if ($import instanceof ShouldQueue) {
             return new PendingDispatch(
-                (new QueueImport($import))->chain($jobs->toArray())
+                (new QueueImport($import))->onQueue($queue)->chain(
+                        $jobs->map(function ($job) use ($queue) {
+                            return $job->onQueue($queue);
+                        })->toArray()
+                    )
             );
         }
 


### PR DESCRIPTION
Fixed default queue still being used when import specifies the queue name.