### PR TITLE
Add assertExportedInRaw assertion

### DIFF
--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
  * @method static BinaryFileResponse download(object $export, string $fileName, string $writerType = null, array $headers = [])
  * @method static bool store(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
  * @method static PendingDispatch queue(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+ * @method static string raw(object $export, string $writerType)
  * @method static BaseExcel import(object $import, string|UploadedFile $filePath, string $disk = null, string $readerType = null)
  * @method static array toArray(object $import, string|UploadedFile $filePath, string $disk = null, string $readerType = null)
  * @method static Collection toCollection(object $import, string|UploadedFile $filePath, string $disk = null, string $readerType = null)
@@ -24,6 +25,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
  * @method static void assertStored(string $filePath, string|callable $disk = null, callable $callback = null)
  * @method static void assertQueued(string $filePath, string|callable $disk = null, callable $callback = null)
  * @method static void assertQueuedWithChain(array $chain)
+ * @method static void assertExportedInRaw(string $classname, callable $callback = null)
  * @method static void assertImported(string $filePath, string|callable $disk = null, callable $callback = null)
  */
 class Excel extends Facade

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -34,6 +34,11 @@ class ExcelFake implements Exporter, Importer
     /**
      * @var array
      */
+    protected $raws = [];
+
+    /**
+     * @var array
+     */
     protected $imported = [];
 
     /**
@@ -103,6 +108,8 @@ class ExcelFake implements Exporter, Importer
      */
     public function raw($export, string $writerType)
     {
+        $this->raws[get_class($export)] = $export;
+
         return 'RAW-CONTENTS';
     }
 
@@ -294,6 +301,24 @@ class ExcelFake implements Exporter, Importer
     public function assertQueuedWithChain($chain): void
     {
         Queue::assertPushedWithChain(get_class($this->job), $chain);
+    }
+
+    /**
+     * @param string        $classname
+     * @param callable|null $callback
+     */
+    public function assertExportedInRaw(string $classname, $callback = null)
+    {
+        Assert::assertArrayHasKey($classname, $this->raws, sprintf('%s is not exported in raw', $classname));
+
+        $callback = $callback ?: function () {
+            return true;
+        };
+
+        Assert::assertTrue(
+            $callback($this->raws[$classname]),
+            "The [{$classname}] export was not exported in raw with the expected data."
+        );
     }
 
     /**

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -144,6 +144,23 @@ class ExcelFakeTest extends TestCase
     /**
      * @test
      */
+    public function can_assert_against_a_fake_raw_export()
+    {
+        ExcelFacade::fake();
+
+        $response = ExcelFacade::raw($this->givenExport(), \Maatwebsite\Excel\Excel::XLSX);
+
+        $this->assertIsString($response);
+
+        ExcelFacade::assertExportedInRaw(get_class($this->givenExport()));
+        ExcelFacade::assertExportedInRaw(get_class($this->givenExport()), function (FromCollection $export) {
+            return $export->collection()->contains('foo');
+        });
+    }
+
+    /**
+     * @test
+     */
     public function can_assert_against_a_fake_import()
     {
         ExcelFacade::fake();


### PR DESCRIPTION
This PR adds the `assertExportedInRaw` assertion.

## Example

```php
Excel::assertExportedInRaw(UsersExport::class, function ($export) {
    return $export->collection()->contains('john');
});
```

## Why?

You may have to store an export without using `Excel::store()` but another system using `raw()` method. In this case, there is today no way to verify the content of this export.