### PR TITLE
Fix Exportable disk options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Make TransactionManager a singleton (#3270)
+- Fix Exportable disk options (#3296)
 
 ## [3.1.32] - 2021-07-08
 

--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -52,7 +52,7 @@ trait Exportable
             $filePath,
             $disk ?? $this->disk ?? null,
             $writerType ?? $this->writerType ?? null,
-            $diskOptions ?? $this->diskOptions ?? []
+            $diskOptions ?: $this->diskOptions ?? []
         );
     }
 
@@ -78,7 +78,7 @@ trait Exportable
             $filePath,
             $disk ?? $this->disk ?? null,
             $writerType ?? $this->writerType ?? null,
-            $diskOptions ?? $this->diskOptions ?? []
+            $diskOptions ?: $this->diskOptions ?? []
         );
     }
 

--- a/tests/Concerns/ExportableTest.php
+++ b/tests/Concerns/ExportableTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Excel;
+use Maatwebsite\Excel\Exporter;
 use Maatwebsite\Excel\Tests\Data\Stubs\EmptyExport;
 use Maatwebsite\Excel\Tests\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -144,5 +145,141 @@ class ExportableTest extends TestCase
         $response = $export->raw(Excel::XLSX);
 
         $this->assertNotEmpty($response);
+    }
+
+    /**
+     * @test
+     */
+    public function can_have_customized_disk_options_when_storing()
+    {
+        $export = new EmptyExport;
+
+        $this->mock(Exporter::class)
+            ->shouldReceive('store')->once()
+            ->with($export, 'name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+
+        $export->store('name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+    }
+
+    /**
+     * @test
+     */
+    public function can_have_customized_disk_options_when_queueing()
+    {
+        $export = new EmptyExport;
+
+        $this->mock(Exporter::class)
+            ->shouldReceive('queue')->once()
+            ->with($export, 'name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+
+        $export->queue('name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+    }
+
+    /**
+     * @test
+     */
+    public function can_set_disk_options_in_export_class_when_storing()
+    {
+        $export = new class
+        {
+            use Exportable;
+
+            public $disk = 's3';
+            public $writerType = Excel::CSV;
+            public $diskOptions = ['visibility' => 'private'];
+        };
+
+        $this->mock(Exporter::class)
+            ->shouldReceive('store')->once()
+            ->with($export, 'name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+
+        $export->store('name.csv');
+    }
+
+    /**
+     * @test
+     */
+    public function can_set_disk_options_in_export_class_when_queuing()
+    {
+        $export = new class
+        {
+            use Exportable;
+
+            public $disk = 's3';
+            public $writerType = Excel::CSV;
+            public $diskOptions = ['visibility' => 'private'];
+        };
+
+        $this->mock(Exporter::class)
+            ->shouldReceive('queue')->once()
+            ->with($export, 'name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+
+        $export->queue('name.csv');
+    }
+
+    /**
+     * @test
+     */
+    public function can_override_export_class_disk_options_when_calling_store()
+    {
+        $export = new class
+        {
+            use Exportable;
+
+            public $diskOptions = ['visibility' => 'public'];
+        };
+
+        $this->mock(Exporter::class)
+            ->shouldReceive('store')->once()
+            ->with($export, 'name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+
+        $export->store('name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+    }
+
+    /**
+     * @test
+     */
+    public function can_override_export_class_disk_options_when_calling_queue()
+    {
+        $export = new class
+        {
+            use Exportable;
+
+            public $diskOptions = ['visibility' => 'public'];
+        };
+
+        $this->mock(Exporter::class)
+            ->shouldReceive('queue')->once()
+            ->with($export, 'name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+
+        $export->queue('name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
+    }
+
+    /**
+     * @test
+     */
+    public function can_have_empty_disk_options_when_storing()
+    {
+        $export = new EmptyExport;
+
+        $this->mock(Exporter::class)
+            ->shouldReceive('store')->once()
+            ->with($export, 'name.csv', null, null, []);
+
+        $export->store('name.csv');
+    }
+
+    /**
+     * @test
+     */
+    public function can_have_empty_disk_options_when_queueing()
+    {
+        $export = new EmptyExport;
+
+        $this->mock(Exporter::class)
+            ->shouldReceive('queue')->once()
+            ->with($export, 'name.csv', null, null, []);
+
+        $export->queue('name.csv');
     }
 }


### PR DESCRIPTION
This fixes an issue where disk options defined in the exportable class were never used.

Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

### Description of issue

The problem was the first null coalescing operator in the expression: 

```php
$diskOptions ?? $this->diskOptions ?? []
```

Since the method signature for `store` and `queue` defines `$diskOptions` as an empty array the null coalescing operator never evaluates the right side of the expression.

### Description of the fix

Using the `?:` operator will evaluate the right side when no value is provided since an empty array is considered a falsy value and use `$this->diskOptions ?? []` as expected.

### Any drawbacks? Possible breaking changes?

Decided not to change the method signature to keep the https://github.com/Maatwebsite/Laravel-Excel/blob/3.1/src/Exporter.php interface the same and avoid a possible breaking change.

Also, tested in all supported PHP versions using: https://3v4l.org/oSIGE 

```php
$export = new class {};
$diskOptions = [];

var_dump($diskOptions ?: $export->diskOptions ?? []);  // => []

$diskOptions = ['visibility' => 'public'];
var_dump($diskOptions ?: $export->diskOptions ?? []); // => ['visibility' => 'public']

$diskOptions = [];
$export->diskOptions = ['visibility' => 'private'];
var_dump($diskOptions ?: $export->diskOptions ?? []); // => ['visibility' => 'private']

```
