### PR TITLE
Feature/refactor config local path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Change default local_path configuration
+
 ## [3.1.33] - 2021-08-12
 
 ### Fixed

--- a/config/excel.php
+++ b/config/excel.php
@@ -289,7 +289,7 @@ return [
         | storing reading or downloading. Here you can customize that path.
         |
         */
-        'local_path'          => storage_path('framework/laravel-excel'),
+        'local_path'          => storage_path('framework/cache/laravel-excel'),
 
         /*
         |--------------------------------------------------------------------------


### PR DESCRIPTION
Proposal to improve the temporary_files->local_path configuration in the default config/excel.php file:
'temporary_files' => [

        /*
        |--------------------------------------------------------------------------
        | Local Temporary Path
        |--------------------------------------------------------------------------
        |
        | When exporting and importing files, we use a temporary file, before
        | storing reading or downloading. Here you can customize that path.
        |
        */
        'local_path'          => storage_path('framework/laravel-excel'),
]

because under the current configuration, there will be tmp files appearing in Git local changes.
i think we need to ignore it in git config.
And to make it simpler, I think I can change the path to put in the cache folder, it's quite reasonable.

We can change the light storage_path('framework/cache/laravel-excel') instead of storage_path('framework/laravel-excel')

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Updated the changelog
