### PR TITLE
Fix queueImport function to be able to assert chained jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Change default local_path configuration
+- Fix queueImport function to be able to assert chained jobs
+
 
 ## [3.1.33] - 2021-08-12
 

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -185,7 +185,7 @@ class ExcelFake implements Exporter, Importer
         $this->queued[$disk ?? 'default'][$filePath]   = $import;
         $this->imported[$disk ?? 'default'][$filePath] = $import;
 
-        return new PendingDispatch(new class
+        $this->job = new class
         {
             use Queueable;
 
@@ -193,7 +193,11 @@ class ExcelFake implements Exporter, Importer
             {
                 //
             }
-        });
+        };
+
+        Queue::push($this->job);
+
+        return new PendingDispatch($this->job);
     }
 
     /**

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -235,6 +235,24 @@ class ExcelFakeTest extends TestCase
     /**
      * @test
      */
+    public function can_assert_against_a_fake_queued_import_with_chain()
+    {
+        ExcelFacade::fake();
+
+        ExcelFacade::queueImport(
+            $this->givenQueuedImport(), 'queued-filename.csv', 's3'
+        )->chain([
+            new ChainedJobStub(),
+        ]);
+
+        ExcelFacade::assertQueuedWithChain([
+            new ChainedJobStub(),
+        ]);
+    }
+
+    /**
+     * @test
+     */
     public function a_callback_can_be_passed_as_the_second_argument_when_asserting_against_a_faked_queued_export()
     {
         ExcelFacade::fake();


### PR DESCRIPTION
This PR is to enable `assertQueuedWithChain` to be used in the `queueImport`.

## Example

```php
        ExcelFacade::queueImport(
            $this->givenQueuedImport(), 'queued-filename.csv', 's3'
        )->chain([
            new ChainedJobStub(),
        ]);

        ExcelFacade::assertQueuedWithChain([ // assert a chained job
            new ChainedJobStub(),
        ]);
```

## Why?

When executing the queueImport function, the job added by chain cannot be asserted by the test function today.
#3333 

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

Please point out any corrections.