### PR TITLE
Implement PHP 8.1's ArrayAccess interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Fix queueImport function to be able to assert chained jobs
 - Skipped failure no longer persists in `ToCollection` and `ToArray`.
 - Fix missing InteractsWithQueue trait in AppendToSheet jobs
+- Add return types to `Row`'s `ArrayAccess` implementation
 
 ## [3.1.33] - 2021-08-12
 

--- a/src/Row.php
+++ b/src/Row.php
@@ -114,22 +114,26 @@ class Row implements ArrayAccess
         return $this->row->getRowIndex();
     }
 
-    public function offsetExists($offset): bool
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
     {
         return isset(($this->toArray())[$offset]);
     }
 
-    public function offsetGet($offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         return ($this->toArray())[$offset];
     }
 
-    public function offsetSet($offset, $value): void
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
     {
         //
     }
 
-    public function offsetUnset($offset): void
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
     {
         //
     }

--- a/src/Row.php
+++ b/src/Row.php
@@ -114,22 +114,22 @@ class Row implements ArrayAccess
         return $this->row->getRowIndex();
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset(($this->toArray())[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return ($this->toArray())[$offset];
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         //
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         //
     }


### PR DESCRIPTION
PHP 8.1 enforces return types for `ArrayAccess` implementations.

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

PHP 8.1 Support

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣  Does it include tests, if possible?

No

4️⃣  Any drawbacks? Possible breaking changes?

I believe that the minimum version PHP 7.2 should be ok, but can't say for certain.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
