### PR TITLE
Fixed SkipsEmptyRows support with the WithColumnLimit concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `SkipsEmptyRows` support with the `WithColumnLimit` concern
+
 ## [3.1.34] - 2021-12-2
 
 ### Changed

--- a/src/Row.php
+++ b/src/Row.php
@@ -99,7 +99,7 @@ class Row implements ArrayAccess
     }
 
     /**
-     * @param bool        $calculateFormulas
+     * @param bool  $calculateFormulas
      * @param string|null $endColumn
      * @return bool
      */

--- a/src/Row.php
+++ b/src/Row.php
@@ -99,11 +99,13 @@ class Row implements ArrayAccess
     }
 
     /**
+     * @param bool        $calculateFormulas
+     * @param string|null $endColumn
      * @return bool
      */
-    public function isEmpty($calculateFormulas = false): bool
+    public function isEmpty($calculateFormulas = false, ?string $endColumn = null): bool
     {
-        return count(array_filter($this->toArray(null, $calculateFormulas, false))) === 0;
+        return count(array_filter($this->toArray(null, $calculateFormulas, false, $endColumn))) === 0;
     }
 
     /**

--- a/src/Row.php
+++ b/src/Row.php
@@ -99,8 +99,8 @@ class Row implements ArrayAccess
     }
 
     /**
-     * @param bool  $calculateFormulas
-     * @param string|null $endColumn
+     * @param  bool  $calculateFormulas
+     * @param  string|null  $endColumn
      * @return bool
      */
     public function isEmpty($calculateFormulas = false, ?string $endColumn = null): bool

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -340,7 +340,7 @@ class Sheet
         foreach ($this->worksheet->getRowIterator($startRow, $endRow) as $index => $row) {
             $row = new Row($row, $headingRow);
 
-            if ($import instanceof SkipsEmptyRows && $row->isEmpty($calculateFormulas)) {
+            if ($import instanceof SkipsEmptyRows && $row->isEmpty($calculateFormulas, $endColumn)) {
                 continue;
             }
 

--- a/tests/Concerns/WithColumnLimitTest.php
+++ b/tests/Concerns/WithColumnLimitTest.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\WithColumnLimit;
 use Maatwebsite\Excel\Tests\TestCase;
@@ -51,5 +52,50 @@ class WithColumnLimitTest extends TestCase
         };
 
         $import->import('import-users.xlsx');
+    }
+
+    /**
+     * @test
+     */
+    public function can_import_to_array_with_column_limit_and_skips_empty_rows()
+    {
+        $import = new class implements ToArray, WithColumnLimit, SkipsEmptyRows
+        {
+            use Importable;
+
+            /**
+             * @param  array  $array
+             */
+            public function array(array $array)
+            {
+                Assert::assertEquals([
+                    [
+                        'Test1',
+                        'Test2',
+                        null,
+                        null
+                    ],
+                    [
+                        'Test3',
+                        'Test4',
+                        null,
+                        null
+                    ],
+                    [
+                        'Test5',
+                        'Test6',
+                        null,
+                        null
+                    ],
+                ], $array);
+            }
+
+            public function endColumn(): string
+            {
+                return 'D';
+            }
+        };
+
+        $import->import('import-empty-rows.xlsx');
     }
 }

--- a/tests/Concerns/WithColumnLimitTest.php
+++ b/tests/Concerns/WithColumnLimitTest.php
@@ -73,19 +73,19 @@ class WithColumnLimitTest extends TestCase
                         'Test1',
                         'Test2',
                         null,
-                        null
+                        null,
                     ],
                     [
                         'Test3',
                         'Test4',
                         null,
-                        null
+                        null,
                     ],
                     [
                         'Test5',
                         'Test6',
                         null,
-                        null
+                        null,
                     ],
                 ], $array);
             }


### PR DESCRIPTION
In this [PR](https://github.com/SpartnerNL/Laravel-Excel/commit/374f8f048221580fbdad8516e2128d2df041e381), the `WithColumnLimit` concern was added.
However the PR didn't take into account the ability to use `WithColumnLimit` at the same time as the other `SkipsEmptyRows` concern.
The `toArray` function of the `Sheet` class is looping through each row in the worksheet. For every row, if the `SkipsEmptyRows` concern is implemented, the `isEmpty` function is checking that the current row is not empty, NOT taking into account the ending column set implementing the `WithColumnLimit` concern. The result is that the current row is cached; getting it, the column limit is ignored.

1️⃣  Why should it be added? What are the benefits of this change?
The benefit is to give the community the ability to use the `WithColumnLimit` and `SkipsEmptyRows` concerns together.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
Yes

4️⃣  Any drawbacks? Possible breaking changes?
No

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
