### PR TITLE
Removed cache flush exporting files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Added `flush_writing` configuration to avoid flushing the cache exporting files
 - Fix `SkipsEmptyRows` support with the `WithColumnLimit` concern
 - formatColumn added range support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Added `flush_writing` configuration to avoid flushing the cache exporting files
+- Removed cache flush exporting files
 - Fix `SkipsEmptyRows` support with the `WithColumnLimit` concern
 - formatColumn added range support
 

--- a/config/excel.php
+++ b/config/excel.php
@@ -226,7 +226,7 @@ return [
         | Drivers: memory|illuminate|batch
         |
         */
-        'driver'     => 'memory',
+        'driver'        => 'memory',
 
         /*
         |--------------------------------------------------------------------------
@@ -238,7 +238,7 @@ return [
         | Here you can tweak the memory limit to your liking.
         |
         */
-        'batch'     => [
+        'batch'         => [
             'memory_limit' => 60000,
         ],
 
@@ -254,9 +254,22 @@ return [
         | at "null" it will use the default store.
         |
         */
-        'illuminate' => [
+        'illuminate'    => [
             'store' => null,
         ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Clear cache writing
+        |--------------------------------------------------------------------------
+        |
+        | When using the "illuminate" caching driver, exporting files,
+        | the default writer instance will flush the cache at the end
+        | of its process. You can set this to true if you want to avoid
+        | flushing the cache.
+        |
+        */
+        'flush_writing' => true,
     ],
 
     /*

--- a/config/excel.php
+++ b/config/excel.php
@@ -226,7 +226,7 @@ return [
         | Drivers: memory|illuminate|batch
         |
         */
-        'driver'        => 'memory',
+        'driver'     => 'memory',
 
         /*
         |--------------------------------------------------------------------------
@@ -238,7 +238,7 @@ return [
         | Here you can tweak the memory limit to your liking.
         |
         */
-        'batch'         => [
+        'batch'     => [
             'memory_limit' => 60000,
         ],
 
@@ -254,22 +254,9 @@ return [
         | at "null" it will use the default store.
         |
         */
-        'illuminate'    => [
+        'illuminate' => [
             'store' => null,
         ],
-
-        /*
-        |--------------------------------------------------------------------------
-        | Clear cache writing
-        |--------------------------------------------------------------------------
-        |
-        | When using the "illuminate" caching driver, exporting files,
-        | the default writer instance will flush the cache at the end
-        | of its process. You can set this to true if you want to avoid
-        | flushing the cache.
-        |
-        */
-        'flush_writing' => true,
     ],
 
     /*

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -146,7 +146,9 @@ class Writer
         $this->clearListeners();
         $this->spreadsheet->disconnectWorksheets();
         unset($this->spreadsheet);
-        app(CacheManager::class)->flush();
+        if (config('excel.cache.flush_writing', true)) {
+            app(CacheManager::class)->flush();
+        }
 
         return $temporaryFile;
     }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -146,9 +146,6 @@ class Writer
         $this->clearListeners();
         $this->spreadsheet->disconnectWorksheets();
         unset($this->spreadsheet);
-        if (config('excel.cache.flush_writing', true)) {
-            app(CacheManager::class)->flush();
-        }
 
         return $temporaryFile;
     }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel;
 
-use Maatwebsite\Excel\Cache\CacheManager;
 use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -180,28 +180,6 @@ class QueuedExportTest extends TestCase
     /**
      * @test
      */
-    public function can_queue_export_flushing_the_cache()
-    {
-        config()->set('excel.cache.driver', 'illuminate');
-        config()->set('excel.cache.flush_writing', true);
-
-        Cache::put('test', 'test');
-
-        $export = new QueuedExport();
-
-        $export->queue('queued-export.xlsx')->chain([
-            new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-export.xlsx'),
-        ]);
-
-        $array = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-export.xlsx', Excel::XLSX);
-        $this->assertCount(100, $array);
-
-        $this->assertNull(Cache::get('test'));
-    }
-
-    /**
-     * @test
-     */
     public function can_queue_export_not_flushing_the_cache()
     {
         config()->set('excel.cache.driver', 'illuminate');

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel\Tests;
 
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
 use Maatwebsite\Excel\Excel;
 use Maatwebsite\Excel\Files\RemoteTemporaryFile;
@@ -174,5 +175,49 @@ class QueuedExportTest extends TestCase
         $this->assertTrue(app('queue-has-correct-locale'));
 
         $this->assertEquals($currentLocale, app()->getLocale());
+    }
+
+    /**
+     * @test
+     */
+    public function can_queue_export_flushing_the_cache()
+    {
+        config()->set('excel.cache.driver', 'illuminate');
+        config()->set('excel.cache.flush_writing', true);
+
+        Cache::put('test', 'test');
+
+        $export = new QueuedExport();
+
+        $export->queue('queued-export.xlsx')->chain([
+            new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-export.xlsx'),
+        ]);
+
+        $array = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-export.xlsx', Excel::XLSX);
+        $this->assertCount(100, $array);
+
+        $this->assertNull(Cache::get('test'));
+    }
+
+    /**
+     * @test
+     */
+    public function can_queue_export_not_flushing_the_cache()
+    {
+        config()->set('excel.cache.driver', 'illuminate');
+        config()->set('excel.cache.flush_writing', false);
+
+        Cache::put('test', 'test');
+
+        $export = new QueuedExport();
+
+        $export->queue('queued-export.xlsx')->chain([
+            new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-export.xlsx'),
+        ]);
+
+        $array = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-export.xlsx', Excel::XLSX);
+        $this->assertCount(100, $array);
+
+        $this->assertEquals('test', Cache::get('test'));
     }
 }

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -183,7 +183,6 @@ class QueuedExportTest extends TestCase
     public function can_queue_export_not_flushing_the_cache()
     {
         config()->set('excel.cache.driver', 'illuminate');
-        config()->set('excel.cache.flush_writing', false);
 
         Cache::put('test', 'test');
 


### PR DESCRIPTION
The `Writer` class, in the `write` function, is flushing the cache at the end of its process.
Using the `illuminate` cache driver, this will result in flushing the entire cache, losing:
- All the keys stored by other jobs/processes.
- Other potential export jobs.

1️⃣  Why should it be added? What are the benefits of this change?
The benefit is to allow multiple exports at the same time, without losing any job/keys stored in the cache.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
Yes

4️⃣  Any drawbacks? Possible breaking changes?
No

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
