### PR TITLE
Make export queuable on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Action can use a method `shouldQueue(): bool` to make them queuable on demand
 - Fix return type of `FromQuery::query()`
 
 ## [3.1.35] - 2022-01-04

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -92,7 +92,10 @@ class Excel implements Exporter, Importer
      */
     public function store($export, string $filePath, string $diskName = null, string $writerType = null, $diskOptions = [])
     {
-        if ($export instanceof ShouldQueue) {
+        if (
+            $export instanceof ShouldQueue ||
+            (method_exists($export, 'shouldQueue') && $export->shouldQueue())
+        ) {
             return $this->queue($export, $filePath, $diskName, $writerType, $diskOptions);
         }
 


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

Sometimes we don't know in advance if we want to queue things or not (for instance it depends of the number of row selected), this MR 

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣  Does it include tests, if possible?

No

4️⃣  Any drawbacks? Possible breaking changes?

The main drawbacks is having a method to document that differ a bit from the Laraval way of handling actions

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌