### PR TITLE
Add support for Laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,10 +24,12 @@ jobs:
     strategy:
       matrix:
         php: [7.2, 7.3, 7.4, 8.0, 8.1]
-        laravel: [8, 7, 6, 5.8]
+        laravel: [9, 8, 7, 6, 5.8]
         dependency-version: [prefer-stable]
         os: [ubuntu-latest]
         include:
+          - laravel: 9
+            testbench: 7.*
           - laravel: 8
             testbench: 6.*
           - laravel: 7
@@ -37,6 +39,12 @@ jobs:
           - laravel: 5.8
             testbench: 3.8.*
         exclude:
+          - laravel: 9
+            php: 7.4
+          - laravel: 9
+            php: 7.3
+          - laravel: 9
+            php: 7.2
           - laravel: 8
             php: 7.2
           - laravel: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fix return type of `FromQuery::query()`
+- Support Laravel 9
 
 ## [3.1.35] - 2022-01-04
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "ext-json": "*",
     "php": "^7.0|^8.0",
     "phpoffice/phpspreadsheet": "^1.18",
-    "illuminate/support": "5.8.*|^6.0|^7.0|^8.0"
+    "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0"
   },
   "require-dev": {
     "orchestra/testbench": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^6.0",
+    "orchestra/testbench": "^6.0|^7.0",
     "predis/predis": "^1.1"
   },
   "autoload": {


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
This PR will add support for Laravel 9 that will be released on 25th this month.

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog
