### PR TITLE
Allow setting db connection from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Fix return type of `FromQuery::query()`
 - Support Laravel 9
+- Added a config setting to specify DB connection
 
 ## [3.1.35] - 2022-01-04
 

--- a/config/excel.php
+++ b/config/excel.php
@@ -276,6 +276,9 @@ return [
     */
     'transactions' => [
         'handler' => 'db',
+        'db' => [
+            'connection' => null
+        ]
     ],
 
     'temporary_files' => [

--- a/config/excel.php
+++ b/config/excel.php
@@ -276,9 +276,9 @@ return [
     */
     'transactions' => [
         'handler' => 'db',
-        'db' => [
+        'db'      => [
             'connection' => null,
-        ]
+        ],
     ],
 
     'temporary_files' => [

--- a/config/excel.php
+++ b/config/excel.php
@@ -277,7 +277,7 @@ return [
     'transactions' => [
         'handler' => 'db',
         'db' => [
-            'connection' => null
+            'connection' => null,
         ]
     ],
 

--- a/src/Transactions/TransactionManager.php
+++ b/src/Transactions/TransactionManager.php
@@ -29,7 +29,7 @@ class TransactionManager extends Manager
     public function createDbDriver()
     {
         return new DbTransactionHandler(
-            DB::connection()
+            DB::connection(config('excel.transactions.db.connection'))
         );
     }
 }


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
It allows setting db connection from config instead of forcing default connection.
For multi-connection applications.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣  Does it include tests, if possible?
No tests included.
Tried but failed to get second connection to work in test setup.
Verified on actual application. 
All existing tests pass.

4️⃣  Any drawbacks? Possible breaking changes?
No. Default config is set to work as before.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
