### PR TITLE
Added an ability to specify CSV ouput encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Fix return type of `FromQuery::query()`
 - Support Laravel 9
 - Added a config setting to specify DB connection
+- Added a config setting to specify CSV output encoding
+- Added an ability to specify CSV ouput encoding through csvSettings
 
 ## [3.1.35] - 2022-01-04
 

--- a/config/excel.php
+++ b/config/excel.php
@@ -48,7 +48,7 @@ return [
             'use_bom'                => false,
             'include_separator_line' => false,
             'excel_compatibility'    => false,
-            'output_encoding'        => 'UTF-8',
+            'output_encoding'        => '',
         ],
 
         /*

--- a/config/excel.php
+++ b/config/excel.php
@@ -48,6 +48,7 @@ return [
             'use_bom'                => false,
             'include_separator_line' => false,
             'excel_compatibility'    => false,
+            'output_encoding'        => 'UTF-8',
         ],
 
         /*

--- a/src/Concerns/MapsCsvSettings.php
+++ b/src/Concerns/MapsCsvSettings.php
@@ -52,6 +52,11 @@ trait MapsCsvSettings
     protected static $inputEncoding = 'UTF-8';
 
     /**
+     * @var string
+     */
+    protected static $outputEncoding = 'UTF-8';
+
+    /**
      * @param  array  $config
      */
     public static function applyCsvSettings(array $config)
@@ -65,5 +70,6 @@ trait MapsCsvSettings
         static::$escapeCharacter      = Arr::get($config, 'escape_character', static::$escapeCharacter);
         static::$contiguous           = Arr::get($config, 'contiguous', static::$contiguous);
         static::$inputEncoding        = Arr::get($config, 'input_encoding', static::$inputEncoding);
+        static::$outputEncoding       = Arr::get($config, 'output_encoding', static::$outputEncoding);
     }
 }

--- a/src/Concerns/MapsCsvSettings.php
+++ b/src/Concerns/MapsCsvSettings.php
@@ -54,7 +54,7 @@ trait MapsCsvSettings
     /**
      * @var string
      */
-    protected static $outputEncoding = 'UTF-8';
+    protected static $outputEncoding = '';
 
     /**
      * @param  array  $config

--- a/src/Factories/WriterFactory.php
+++ b/src/Factories/WriterFactory.php
@@ -56,6 +56,8 @@ class WriterFactory
             $writer->setUseBOM(static::$useBom);
             $writer->setIncludeSeparatorLine(static::$includeSeparatorLine);
             $writer->setExcelCompatibility(static::$excelCompatibility);
+            $writer->setOutputEncoding(static::$outputEncoding);
+
         }
 
         // Calculation settings

--- a/src/Factories/WriterFactory.php
+++ b/src/Factories/WriterFactory.php
@@ -57,7 +57,6 @@ class WriterFactory
             $writer->setIncludeSeparatorLine(static::$includeSeparatorLine);
             $writer->setExcelCompatibility(static::$excelCompatibility);
             $writer->setOutputEncoding(static::$outputEncoding);
-
         }
 
         // Calculation settings

--- a/tests/Concerns/WithCustomCsvSettingsTest.php
+++ b/tests/Concerns/WithCustomCsvSettingsTest.php
@@ -54,6 +54,7 @@ class WithCustomCsvSettingsTest extends TestCase
                     'use_bom'                => true,
                     'include_separator_line' => true,
                     'excel_compatibility'    => false,
+                    'output_encoding'        => 'UTF-8',
                 ];
             }
         };
@@ -65,6 +66,55 @@ class WithCustomCsvSettingsTest extends TestCase
         $this->assertStringContains('sep=;', $contents);
         $this->assertStringContains('A1;B1', $contents);
         $this->assertStringContains('A2;B2', $contents);
+    }
+
+    /**
+     * @test
+     */
+    public function can_store_csv_export_with_custom_encoding()
+    {
+        $export = new class implements FromCollection, WithCustomCsvSettings
+        {
+            /**
+             * @return Collection
+             */
+            public function collection()
+            {
+                return collect([
+                    ['A1', '€ŠšŽžŒœŸ'],
+                    ['A2', 'åßàèòìù'],
+                ]);
+            }
+
+            /**
+             * @return array
+             */
+            public function getCsvSettings(): array
+            {
+                return [
+                    'delimiter'              => ';',
+                    'enclosure'              => '',
+                    'line_ending'            => PHP_EOL,
+                    'use_bom'                => false,
+                    'include_separator_line' => true,
+                    'excel_compatibility'    => false,
+                    'output_encoding'        => 'ISO-8859-15',
+                ];
+            }
+        };
+
+        $this->SUT->store($export, 'custom-csv-iso.csv');
+
+        $contents = file_get_contents(__DIR__ . '/../Data/Disks/Local/custom-csv-iso.csv');
+
+        Assert::assertEquals('ISO-8859-15', mb_detect_encoding($contents, 'ISO-8859-15', true));
+        Assert::assertFalse(mb_detect_encoding($contents, 'UTF-8', true));
+
+        $contents = mb_convert_encoding($contents, 'UTF-8', 'ISO-8859-15');
+
+        $this->assertStringContains('sep=;', $contents);
+        $this->assertStringContains('A1;€ŠšŽžŒœŸ', $contents);
+        $this->assertStringContains('A2;åßàèòìù', $contents);
     }
 
     /**

--- a/tests/Concerns/WithCustomCsvSettingsTest.php
+++ b/tests/Concerns/WithCustomCsvSettingsTest.php
@@ -54,7 +54,7 @@ class WithCustomCsvSettingsTest extends TestCase
                     'use_bom'                => true,
                     'include_separator_line' => true,
                     'excel_compatibility'    => false,
-                    'output_encoding'        => 'UTF-8',
+                    'output_encoding'        => '',
                 ];
             }
         };


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
sometimes it is necessary to be able to export a CSV file directly with an encoding different from UTF-8

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
Yes

4️⃣  Any drawbacks? Possible breaking changes?
No, the default is 'UTF-8'

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
