### PR TITLE
Add `@mixin` docblock to all macroable classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Added a config setting to specify DB connection
 - Added a config setting to specify CSV output encoding
 - Added an ability to specify CSV ouput encoding through csvSettings
+- Add `@mixin` docblock to all macroable classes to allow for IDE autocompletion of delegate classes
 
 ## [3.1.35] - 2022-01-04
 

--- a/src/Cell.php
+++ b/src/Cell.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
+/** @mixin SpreadsheetCell */
 class Cell
 {
     use DelegatedMacroable;

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -29,6 +29,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Throwable;
 
+/** @mixin Spreadsheet */
 class Reader
 {
     use DelegatedMacroable, HasEventBus;

--- a/src/Row.php
+++ b/src/Row.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Support\Collection;
 use PhpOffice\PhpSpreadsheet\Worksheet\Row as SpreadsheetRow;
 
+/** @mixin SpreadsheetRow */
 class Row implements ArrayAccess
 {
     use DelegatedMacroable;

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -58,6 +58,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\BaseDrawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
+/** @mixin Worksheet */
 class Sheet
 {
     use DelegatedMacroable, HasEventBus;

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -17,6 +17,7 @@ use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
+/** @mixin Spreadsheet */
 class Writer
 {
     use DelegatedMacroable, HasEventBus;


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

This allows for IDE autocompletion of the underlying PhpSpreadsheet
classes when calling methods on the Laravel Excel classes.

For example:

```php
public static function beforeWriting(BeforeWriting $event): void
{
    $event->getWriter()
          ->getProperties()
          ->setCreator('@squatto');
}
```

Without the `@mixin` docblock, IDEs can't find `->getProperties()`:

<img width="630" alt="Screen Shot 2022-02-10 at 10 55 00 AM" src="https://user-images.githubusercontent.com/748444/153471412-b50a4874-d7b8-4559-a8a3-385efef00b01.png">

With the `@mixin` docblock, IDEs can find `->getProperties()` and autocompletion works as expected:

<img width="730" alt="Screen Shot 2022-02-10 at 10 55 30 AM" src="https://user-images.githubusercontent.com/748444/153471514-5cf5c94d-2f10-495a-816a-e4a93e1739c0.png">

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣  Does it include tests, if possible?

N/A

4️⃣  Any drawbacks? Possible breaking changes?

Nothing that I can think of, given that it only adds docblocks.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
