### PR TITLE
Add custom response headers to Collection Exports

### DIFF
--- a/src/Mixins/DownloadCollection.php
+++ b/src/Mixins/DownloadCollection.php
@@ -16,7 +16,7 @@ class DownloadCollection
      */
     public function downloadExcel()
     {
-        return function (string $fileName, string $writerType = null, $withHeadings = false) {
+        return function (string $fileName, string $writerType = null, $withHeadings = false, array $responseHeaders = []) {
             $export = new class($this, $withHeadings) implements FromCollection, WithHeadings
             {
                 use Exportable;
@@ -68,7 +68,7 @@ class DownloadCollection
                 }
             };
 
-            return $export->download($fileName, $writerType);
+            return $export->download($fileName, $writerType, $responseHeaders);
         };
     }
 }

--- a/tests/Mixins/DownloadCollectionTest.php
+++ b/tests/Mixins/DownloadCollectionTest.php
@@ -86,4 +86,25 @@ class DownloadCollectionTest extends TestCase
 
         $this->assertEquals(['name', 'password'], collect($array)->first());
     }
+
+    /**
+     * @test
+     */
+    public function can_set_custom_response_headers()
+    {
+        $collection = new Collection([
+            ['column_1' => 'test', 'column_2' => 'test'],
+            ['column_1' => 'test2', 'column_2' => 'test2'],
+        ]);
+
+        $responseHeaders = [
+            'CUSTOMER-HEADER-1' => 'CUSTOMER-HEADER1-VAL',
+            'CUSTOMER-HEADER-2' => 'CUSTOMER-HEADER2-VAL',
+        ];
+        /** @var BinaryFileResponse $response */
+        $response = $collection->downloadExcel('collection-download.xlsx', Excel::XLSX, false, $responseHeaders);
+        $this->assertTrue($response->headers->contains('CUSTOMER-HEADER-1', 'CUSTOMER-HEADER1-VAL'));
+        $this->assertTrue($response->headers->contains('CUSTOMER-HEADER-2', 'CUSTOMER-HEADER2-VAL'));
+
+    }
 }


### PR DESCRIPTION
Exposes the ability to set custom response headers when using the DownloadCollection macro.
