### PR TITLE
Fix testing for multiple stored files by regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [3.1.40] - 2022-05-02
 
+- Fix testing for multiple stored files by regex matching (#3631).
+
 ### Changed
 
 - Adds `WithDefaultStyles` concern to allow configuring the workbook default styles.

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -372,7 +372,7 @@ class ExcelFake implements Exporter, Importer
             $results = preg_grep($key, $files);
             Assert::assertGreaterThan(0, count($results), $message);
             Assert::assertEquals(1, count($results), "More than one result matches the file name expression '$key'.");
-           
+
             return array_values($results)[0];
         }
         Assert::assertArrayHasKey($key, $disk, $message);

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -372,8 +372,8 @@ class ExcelFake implements Exporter, Importer
             $results = preg_grep($key, $files);
             Assert::assertGreaterThan(0, count($results), $message);
             Assert::assertEquals(1, count($results), "More than one result matches the file name expression '$key'.");
-
-            return $results[0];
+           
+            return array_values($results)[0];
         }
         Assert::assertArrayHasKey($key, $disk, $message);
 

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -68,6 +68,26 @@ class ExcelFakeTest extends TestCase
     /**
      * @test
      */
+    public function can_assert_regex_against_a_fake_stored_export_with_multiple_files()
+    {
+        ExcelFacade::fake();
+
+        $response = ExcelFacade::store($this->givenExport(), 'stored-filename-one.csv', 's3');
+
+        $this->assertTrue($response);
+
+        $response = ExcelFacade::store($this->givenExport(), 'stored-filename-two.csv', 's3');
+
+        $this->assertTrue($response);
+
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertStored('/\w{6}-\w{8}-one\.csv/', 's3');
+        ExcelFacade::assertStored('/\w{6}-\w{8}-two\.csv/', 's3');
+    }
+
+    /**
+     * @test
+     */
     public function a_callback_can_be_passed_as_the_second_argument_when_asserting_against_a_faked_stored_export()
     {
         ExcelFacade::fake();


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
Attempting to test multiple stored files using regex fails due to the PHP array no longer being an indexed array. 

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
Yes

4️⃣  Any drawbacks? Possible breaking changes?
None

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
