### PR TITLE
Allow validations with toArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+### Changed
+- Adds `WithArrayValidation` concern to allow validations with `Excel::toArray`
 
 ## [3.1.40] - 2022-05-02
 

--- a/src/Concerns/WithArrayValidation.php
+++ b/src/Concerns/WithArrayValidation.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithArrayValidation extends WithValidation
+{
+}

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -17,6 +17,7 @@ use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithArrayValidation;
 use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
 use Maatwebsite\Excel\Concerns\WithCharts;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
@@ -358,6 +359,10 @@ class Sheet
 
             if ($import instanceof WithValidation && method_exists($import, 'prepareForValidation')) {
                 $row = $import->prepareForValidation($row, $index);
+            }
+
+            if ($import instanceof WithArrayValidation) {
+                $rows = $this->validated($import, $startRow, $rows);
             }
 
             $rows[] = $row;

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -91,7 +91,8 @@ class WithValidationTest extends TestCase
      */
     public function can_validate_simple_to_array()
     {
-        $import = new class implements WithArrayValidation {
+        $import = new class implements WithArrayValidation
+        {
             use Importable;
 
             public function rules(): array

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -12,6 +12,7 @@ use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithArrayValidation;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithGroupedHeadingRow;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
@@ -83,6 +84,35 @@ class WithValidationTest extends TestCase
         }
 
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
+    }
+
+    /**
+     * @test
+     */
+    public function can_validate_simple_to_array()
+    {
+        $import = new class implements WithArrayValidation {
+            use Importable;
+
+            public function rules(): array
+            {
+                return ['phone' => 'required'];
+            }
+        };
+
+        try {
+            $import->toArray('import-users-with-headings.xlsx');
+        } catch (ValidationException $e) {
+            $this->validateFailure($e, 1, 'phone', [
+                'The phone field is required.',
+            ]);
+
+            $this->assertEquals([
+                [
+                    'There was an error on row 1. The phone field is required.',
+                ],
+            ], $e->errors());
+        }
     }
 
     /**


### PR DESCRIPTION
Hello, I have a case where I just need to validate the file. and get the rows to process them later. but the issue is -according to docs and code in this repo- `WithValidation` only works with `Excel::import`. and having to do the validation through [Validator::make](https://docs.laravel-excel.com/3.1/imports/validation.html#row-validation-without-tomodel) isn't cool as using the same normal flow as `::import` and also it would keep things consistent.

I don't have much experience with the package and its internals. so I tried my best here in this PR to make things work.

1️⃣  Why should it be added? What are the benefits of this change?
It adds the possibility to validate files with toArray

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope. it's just a single feature.

3️⃣  Does it include tests, if possible?
Yes

4️⃣  Any drawbacks? Possible breaking changes?
Should not be any breaking changes.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

Once merged I'll make another PR to update the docs