### PR TITLE
Simplify validations by using only one concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Adds `WithArrayValidation` concern to allow validations with `Excel::toArray`
+- Support `WithValidation` concern to allow validations with `Excel::toArray()` and `Excel::toCollection()`
 
 ### Fixed
 

--- a/src/Concerns/WithArrayValidation.php
+++ b/src/Concerns/WithArrayValidation.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Maatwebsite\Excel\Concerns;
-
-interface WithArrayValidation extends WithValidation
-{
-}

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -357,11 +357,11 @@ class Sheet
                 $row = $import->map($row);
             }
 
-            if ($import instanceof WithValidation && method_exists($import, 'prepareForValidation')) {
-                $row = $import->prepareForValidation($row, $index);
-            }
+            if ($import instanceof WithValidation) {
+                if (method_exists($import, 'prepareForValidation')) {
+                    $row = $import->prepareForValidation($row, $index);
+                }
 
-            if ($import instanceof WithArrayValidation) {
                 $rows = $this->validated($import, $startRow, $rows);
             }
 

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -17,7 +17,6 @@ use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
-use Maatwebsite\Excel\Concerns\WithArrayValidation;
 use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
 use Maatwebsite\Excel\Concerns\WithCharts;
 use Maatwebsite\Excel\Concerns\WithChunkReading;

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -12,7 +12,6 @@ use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
-use Maatwebsite\Excel\Concerns\WithArrayValidation;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithGroupedHeadingRow;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
@@ -91,7 +90,7 @@ class WithValidationTest extends TestCase
      */
     public function can_validate_simple_to_array()
     {
-        $import = new class implements WithArrayValidation
+        $import = new class implements WithValidation
         {
             use Importable;
 
@@ -103,6 +102,36 @@ class WithValidationTest extends TestCase
 
         try {
             $import->toArray('import-users-with-headings.xlsx');
+        } catch (ValidationException $e) {
+            $this->validateFailure($e, 1, 'phone', [
+                'The phone field is required.',
+            ]);
+
+            $this->assertEquals([
+                [
+                    'There was an error on row 1. The phone field is required.',
+                ],
+            ], $e->errors());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_validate_simple_to_collection()
+    {
+        $import = new class implements WithValidation
+        {
+            use Importable;
+
+            public function rules(): array
+            {
+                return ['phone' => 'required'];
+            }
+        };
+
+        try {
+            $import->toCollection('import-users-with-headings.xlsx');
         } catch (ValidationException $e) {
             $this->validateFailure($e, 1, 'phone', [
                 'The phone field is required.',


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
As requested [here](https://github.com/SpartnerNL/laravel-excel-docs/pull/186). `WithValidation` is the only concern to validating rows. and now `ToArray` and `ToCollection` are validatable imports.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
It's only one feature.

3️⃣  Does it include tests, if possible?
Yes

4️⃣  Any drawbacks? Possible breaking changes?
Should not be any drawbacks.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
