### PR TITLE
Fixed compatibility of MemoryCache class with Psr\SimpleCache\CacheIn…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": "^7.0|^8.0",
+    "php": "^8.0",
     "phpoffice/phpspreadsheet": "^1.18",
     "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0"
   },

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -27,7 +27,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function clear()
+    public function clear(): bool
     {
         $this->cache = [];
 
@@ -37,7 +37,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function delete($key)
+    public function delete(string $key): bool
     {
         unset($this->cache[$key]);
 
@@ -47,7 +47,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple(iterable $keys): bool
     {
         foreach ($keys as $key) {
             $this->delete($key);
@@ -59,7 +59,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         if ($this->has($key)) {
             return $this->cache[$key];
@@ -71,7 +71,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         $results = [];
         foreach ($keys as $key) {
@@ -84,7 +84,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function has($key)
+    public function has(string $key): bool
     {
         return isset($this->cache[$key]);
     }
@@ -92,7 +92,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function set($key, $value, $ttl = null)
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
     {
         $this->cache[$key] = $value;
 
@@ -102,7 +102,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
     {
         foreach ($values as $key => $value) {
             $this->set($key, $value);


### PR DESCRIPTION
Fix for the latest error in `MemoryCache` class that fixes errors such as:

```
Declaration of Maatwebsite\Excel\Cache\MemoryCache::get($key, $default = null) must be compatible with Psr\SimpleCache\CacheInterface::get(string $key, mixed $default = null): mixed
```

Changed also PHP requirement to minimum PHP 8.0 since `CacheInterface` now uses union types supported by PHP 8 only

