### PR TITLE
Revert validation to array introduced in 3.1.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -6,7 +5,6 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Support `WithValidation` concern to allow validations with `Excel::toArray()` and `Excel::toCollection()`
 - Cast empty headings to indexed integer
 - Adds `isEmptyWhen` to customize is row empty logic.
 

--- a/src/Concerns/WithArrayValidation.php
+++ b/src/Concerns/WithArrayValidation.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Maatwebsite\Excel\Concerns;
-
-interface WithArrayValidation extends WithValidation
-{
-}

--- a/src/Concerns/WithArrayValidation.php
+++ b/src/Concerns/WithArrayValidation.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithArrayValidation extends WithValidation
+{
+}

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -17,6 +17,7 @@ use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithArrayValidation;
 use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
 use Maatwebsite\Excel\Concerns\WithCharts;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
@@ -360,11 +361,11 @@ class Sheet
                 $row = $import->map($row);
             }
 
-            if ($import instanceof WithValidation) {
-                if (method_exists($import, 'prepareForValidation')) {
-                    $row = $import->prepareForValidation($row, $index);
-                }
+            if ($import instanceof WithValidation && method_exists($import, 'prepareForValidation')) {
+                $row = $import->prepareForValidation($row, $index);
+            }
 
+            if ($import instanceof WithArrayValidation) {
                 $rows = $this->validated($import, $startRow, $rows);
             }
 

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -17,7 +17,6 @@ use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
-use Maatwebsite\Excel\Concerns\WithArrayValidation;
 use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
 use Maatwebsite\Excel\Concerns\WithCharts;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
@@ -363,10 +362,6 @@ class Sheet
 
             if ($import instanceof WithValidation && method_exists($import, 'prepareForValidation')) {
                 $row = $import->prepareForValidation($row, $index);
-            }
-
-            if ($import instanceof WithArrayValidation) {
-                $rows = $this->validated($import, $startRow, $rows);
             }
 
             $rows[] = $row;

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -12,7 +12,6 @@ use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
-use Maatwebsite\Excel\Concerns\WithArrayValidation;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithGroupedHeadingRow;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
@@ -84,36 +83,6 @@ class WithValidationTest extends TestCase
         }
 
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
-    }
-
-    /**
-     * @test
-     */
-    public function can_validate_simple_to_array()
-    {
-        $import = new class implements WithArrayValidation
-        {
-            use Importable;
-
-            public function rules(): array
-            {
-                return ['phone' => 'required'];
-            }
-        };
-
-        try {
-            $import->toArray('import-users-with-headings.xlsx');
-        } catch (ValidationException $e) {
-            $this->validateFailure($e, 1, 'phone', [
-                'The phone field is required.',
-            ]);
-
-            $this->assertEquals([
-                [
-                    'There was an error on row 1. The phone field is required.',
-                ],
-            ], $e->errors());
-        }
     }
 
     /**

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -12,6 +12,7 @@ use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithArrayValidation;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithGroupedHeadingRow;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
@@ -90,7 +91,7 @@ class WithValidationTest extends TestCase
      */
     public function can_validate_simple_to_array()
     {
-        $import = new class implements WithValidation
+        $import = new class implements WithArrayValidation
         {
             use Importable;
 
@@ -102,36 +103,6 @@ class WithValidationTest extends TestCase
 
         try {
             $import->toArray('import-users-with-headings.xlsx');
-        } catch (ValidationException $e) {
-            $this->validateFailure($e, 1, 'phone', [
-                'The phone field is required.',
-            ]);
-
-            $this->assertEquals([
-                [
-                    'There was an error on row 1. The phone field is required.',
-                ],
-            ], $e->errors());
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function can_validate_simple_to_collection()
-    {
-        $import = new class implements WithValidation
-        {
-            use Importable;
-
-            public function rules(): array
-            {
-                return ['phone' => 'required'];
-            }
-        };
-
-        try {
-            $import->toCollection('import-users-with-headings.xlsx');
         } catch (ValidationException $e) {
             $this->validateFailure($e, 1, 'phone', [
                 'The phone field is required.',


### PR DESCRIPTION
This PR reverts changes made to validation handling, which broke the existing import workflow in certain (important) cases. See #3740.

1️⃣  Why should it be added? What are the benefits of this change?
Fixes #3740

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
It reverts only the changes from #3641, #3642

3️⃣  Does it include tests, if possible?
Not applicable.

4️⃣  Any drawbacks? Possible breaking changes?
Removes the functionality to run validation directly while calling 'toArray' or 'toCollection', which was flawed.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
