### PR TITLE
check that the $import variable is not empty

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -352,7 +352,7 @@ class Sheet
 
             $row = $row->toArray($nullValue, $calculateFormulas, $formatData, $endColumn);
 
-            if (method_exists($import, 'isEmptyWhen') && $import->isEmptyWhen($row)) {
+            if ($import && method_exists($import, 'isEmptyWhen') && $import->isEmptyWhen($row)) {
                 continue;
             }
 

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -260,6 +260,19 @@ class ExcelTest extends TestCase
             ]),
         ]), $import->toCollection('import.xlsx'));
     }
+    
+    /**
+     * @test
+     */
+    public function can_import_a_simple_xlsx_file_to_collection_without_import_object()
+    {
+        $this->assertEquals(new Collection([
+            new Collection([
+                new Collection(['test', 'test']),
+                new Collection(['test', 'test']),
+            ]),
+        ]), ExcelFacade::toCollection(null, 'import.xlsx'));
+    }
 
     /**
      * @test


### PR DESCRIPTION
check that the $import variable is not empty, avoid problems with method_exists(): Argument

TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given