### PR TITLE
Add test to check if WithFormatData works with SkipsEmptyRows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Fix temporary local files not being cleaned up when setting force_resync_remote config to true (#3623)
 - Fix testing for multiple stored files by regex matching (#3631).
 - Allow `required_unless` rule (#3660)
+- Fix output of `WithFormatData` in combination with `SkipsEmptyRows` (#3760)
 
 ## [3.1.40] - 2022-05-02
 

--- a/src/Row.php
+++ b/src/Row.php
@@ -105,7 +105,7 @@ class Row implements ArrayAccess
             $cells = ($this->preparationCallback)($cells, $this->row->getRowIndex());
         }
 
-        $this->rowCache = $cells;
+        $this->rowCache           = $cells;
         $this->rowCacheFormatData = $formatData;
 
         return $cells;

--- a/src/Row.php
+++ b/src/Row.php
@@ -33,6 +33,11 @@ class Row implements ArrayAccess
     protected $rowCache;
 
     /**
+     * @var bool|null
+     */
+    protected $rowCacheFormatData;
+
+    /**
      * @param  SpreadsheetRow  $row
      * @param  array  $headingRow
      * @param  array  $headerIsGrouped
@@ -73,7 +78,7 @@ class Row implements ArrayAccess
      */
     public function toArray($nullValue = null, $calculateFormulas = false, $formatData = true, ?string $endColumn = null)
     {
-        if (is_array($this->rowCache)) {
+        if (is_array($this->rowCache) && ($this->rowCacheFormatData === $formatData)) {
             return $this->rowCache;
         }
 
@@ -101,6 +106,7 @@ class Row implements ArrayAccess
         }
 
         $this->rowCache = $cells;
+        $this->rowCacheFormatData = $formatData;
 
         return $cells;
     }

--- a/tests/Concerns/WithFormatDataTest.php
+++ b/tests/Concerns/WithFormatDataTest.php
@@ -4,6 +4,7 @@ namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -47,6 +48,34 @@ class WithFormatDataTest extends TestCase
     {
         config()->set('excel.imports.read_only', false);
         $import = new class implements ToArray, WithFormatData
+        {
+            use Importable;
+
+            public $called = false;
+
+            /**
+             * @param  array  $array
+             */
+            public function array(array $array)
+            {
+                $this->called = true;
+
+                Assert::assertSame('5/12/2021', $array[0][0]);
+            }
+        };
+
+        $import->import('import-format-data.xlsx');
+
+        $this->assertTrue($import->called);
+    }
+
+    /**
+     * @test
+     */
+    public function can_import_to_array_with_format_data_and_skips_empty_rows()
+    {
+        config()->set('excel.imports.read_only', false);
+        $import = new class implements ToArray, WithFormatData, SkipsEmptyRows
         {
             use Importable;
 


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
Add test to prove #3760

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
Yes: `WithFormatDataTest::can_import_to_array_with_format_data_and_skips_empty_rows`

4️⃣  Any drawbacks? Possible breaking changes?
It adds one test

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
