### PR TITLE
Create path to remote temporary file before creating file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Fix testing for multiple stored files by regex matching (#3631).
 - Allow `required_unless` rule (#3660)
 - Fix output of `WithFormatData` in combination with `SkipsEmptyRows` (#3760)
+- Fix 'No such file or directory' error when creating remote temporary file
 
 ## [3.1.40] - 2022-05-02
 

--- a/src/Files/RemoteTemporaryFile.php
+++ b/src/Files/RemoteTemporaryFile.php
@@ -94,7 +94,14 @@ class RemoteTemporaryFile extends TemporaryFile
     public function sync(): TemporaryFile
     {
         if (!$this->localTemporaryFile->exists()) {
-            touch($this->localTemporaryFile->getLocalPath());
+            $localPath = $this->localTemporaryFile->getLocalPath();
+
+            // create path first if it doesn't already exist
+            if (!file_exists(dirname($localPath))) {
+                mkdir(dirname($localPath), 0777, true);
+            }
+
+            touch($localPath);
         }
 
         $this->disk()->copy(


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
Fixes an issue where imports might fail when using remote temporary files, since the temporary file was being created with `touch()` without first checking if the path to the file existed resulting in a 'No such file or directory' error.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣  Does it include tests, if possible?
Not sure which tests would be appropriate for this fix. Happy to add them if required.

4️⃣  Any drawbacks? Possible breaking changes?
No.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
