### PR TITLE
Add explicit typing to functions of MemoryCache

### DIFF
--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -27,7 +27,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function clear()
+    public function clear() : bool
     {
         $this->cache = [];
 
@@ -37,7 +37,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function delete($key)
+    public function delete($key) : bool
     {
         unset($this->cache[$key]);
 
@@ -47,7 +47,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple($keys) : bool
     {
         foreach ($keys as $key) {
             $this->delete($key);
@@ -59,7 +59,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null) : mixed
     {
         if ($this->has($key)) {
             return $this->cache[$key];
@@ -71,7 +71,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple($keys, $default = null) : iterable
     {
         $results = [];
         foreach ($keys as $key) {
@@ -84,7 +84,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function has($key)
+    public function has($key) : bool
     {
         return isset($this->cache[$key]);
     }
@@ -92,7 +92,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function set($key, $value, $ttl = null)
+    public function set($key, $value, $ttl = null) : bool
     {
         $this->cache[$key] = $value;
 
@@ -102,7 +102,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple($values, $ttl = null) : bool
     {
         foreach ($values as $key => $value) {
             $this->set($key, $value);


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

The PR is fixing the issue #3805. With this change Laravel-Export is again usable with the newest PHP version.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣  Does it include tests, if possible?

4️⃣  Any drawbacks? Possible breaking changes?

No breaking changes. Just describing the return types as described in CacheInterface

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [ ] Updated the changelog

6️⃣  Thanks for contributing! 🙌
