### PR TITLE
Add support for ignoring PHP auto_detect_line_endings INI directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add support for ignoring PHP auto_detect_line_endings INI directive
+
+## [3.1.44] - 2022-10-14
+
+### Fixed
+
+- Fix output of `WithFormatData` in combination with `SkipsEmptyRows` (#3760)
+
 ### Changed
-- Cast empty headings to indexed integer
-- Adds `isEmptyWhen` to customize is row empty logic.
+
+- Cast empty headings to indexed integer (#3646)
+- Adds `isEmptyWhen` to customize is row empty logic. (#3645)
 
 ### Fixed
 
 - Fix temporary local files not being cleaned up when setting force_resync_remote config to true (#3623)
 - Fix testing for multiple stored files by regex matching (#3631).
 - Allow `required_unless` rule (#3660)
-- Fix output of `WithFormatData` in combination with `SkipsEmptyRows` (#3760)
 
 ## [3.1.40] - 2022-05-02
 
@@ -44,18 +53,22 @@ All notable changes to this project will be documented in this file.
 ## [3.1.37] - 2022-02-28
 
 ### Fixed
+
 - Add `@mixin` docblock to all macroable classes to allow for IDE autocompletion of delegate classes
 - Fix issue with `Excel::toArray` not allowing nullable reader types for uploaded files
 
 ### Changed
+
 - Change default Csv Import to auto-detect the delimiter when not explicitly defined
 
 ## [3.1.36] - 2022-02-03
 
 ### Fixed
+
 - Fix return type of `FromQuery::query()`
 
-## Changed
+### Changed
+
 - Support Laravel 9
 - Added a config setting to specify DB connection
 - Added a config setting to specify CSV output encoding

--- a/config/excel.php
+++ b/config/excel.php
@@ -49,6 +49,7 @@ return [
             'include_separator_line' => false,
             'excel_compatibility'    => false,
             'output_encoding'        => '',
+            'test_auto_detect'       => true
         ],
 
         /*

--- a/src/Concerns/MapsCsvSettings.php
+++ b/src/Concerns/MapsCsvSettings.php
@@ -57,6 +57,11 @@ trait MapsCsvSettings
     protected static $outputEncoding = '';
 
     /**
+     * @var bool
+     */
+    protected static $testAutoDetect = true;
+
+    /**
      * @param  array  $config
      */
     public static function applyCsvSettings(array $config)
@@ -71,5 +76,6 @@ trait MapsCsvSettings
         static::$contiguous           = Arr::get($config, 'contiguous', static::$contiguous);
         static::$inputEncoding        = Arr::get($config, 'input_encoding', static::$inputEncoding);
         static::$outputEncoding       = Arr::get($config, 'output_encoding', static::$outputEncoding);
+        static::$testAutoDetect       = Arr::get($config, 'test_auto_detect', static::$testAutoDetect);
     }
 }

--- a/src/Factories/ReaderFactory.php
+++ b/src/Factories/ReaderFactory.php
@@ -53,7 +53,9 @@ class ReaderFactory
             $reader->setEscapeCharacter(static::$escapeCharacter);
             $reader->setContiguous(static::$contiguous);
             $reader->setInputEncoding(static::$inputEncoding);
-            $reader->setTestAutoDetect(static::$testAutoDetect);
+            if (method_exists($reader, 'setTestAutoDetect')) {
+                $reader->setTestAutoDetect(static::$testAutoDetect);
+            }
         }
 
         if ($import instanceof WithReadFilter) {

--- a/src/Factories/ReaderFactory.php
+++ b/src/Factories/ReaderFactory.php
@@ -53,6 +53,7 @@ class ReaderFactory
             $reader->setEscapeCharacter(static::$escapeCharacter);
             $reader->setContiguous(static::$contiguous);
             $reader->setInputEncoding(static::$inputEncoding);
+            $reader->setTestAutoDetect(static::$testAutoDetect);
         }
 
         if ($import instanceof WithReadFilter) {

--- a/tests/Concerns/WithCustomCsvSettingsTest.php
+++ b/tests/Concerns/WithCustomCsvSettingsTest.php
@@ -56,6 +56,7 @@ class WithCustomCsvSettingsTest extends TestCase
                     'include_separator_line' => true,
                     'excel_compatibility'    => false,
                     'output_encoding'        => '',
+                    'test_auto_detect'       => false,
                 ];
             }
         };


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
PHP INI setting `auto_detect_line_endings` is deprecated since PHP 8.1. Dependency `maatwebsite/excel` still supports this setting for it to be used on PHP versions < 8.1, but they also provided a way to disable it for environments using PHP >= 8.1.

This will prevent having deprecation warnings on environments using PHP 8.1.

See: 
- https://github.com/PHPOffice/PhpSpreadsheet/commit/f575d2b8b2f6cc94bb2ae93e7a1933c4fe9e5d55
- https://php.watch/versions/8.1/auto_detect_line_endings-ini-deprecated

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
No, included this setting in an existing test. Do not think an additional specific test is needed since this is mostly just a configuration setting.

4️⃣  Any drawbacks? Possible breaking changes?
No, default value is set to true to match current behaviour and checking for method existence to support earlier versions of `maatwebsite/excel`.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
