### PR TITLE
Added the ability to specify the queue name in implicit queued imports/exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix output of `WithFormatData` in combination with `SkipsEmptyRows` (#3760)
+- Fixed specifying queue name in constructor in implicit queued imports/exports
 
 ### Changed
 

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -82,7 +82,7 @@ class ChunkReader
         if ($import instanceof ShouldQueue) {
             return (new PendingDispatch(
                 (new QueueImport($import))->chain($jobs->toArray())
-            ))->onQueue($import->queue);
+            ))->onQueue($import->queue ?? "");
         }
 
         $jobs->each(function ($job) {

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -80,9 +80,9 @@ class ChunkReader
         $jobs->push($afterImportJob);
 
         if ($import instanceof ShouldQueue) {
-            return new PendingDispatch(
+            return (new PendingDispatch(
                 (new QueueImport($import))->chain($jobs->toArray())
-            );
+            ))->onQueue($import->queue);
         }
 
         $jobs->each(function ($job) {

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -82,7 +82,7 @@ class ChunkReader
         if ($import instanceof ShouldQueue) {
             return (new PendingDispatch(
                 (new QueueImport($import))->chain($jobs->toArray())
-            ))->onQueue($import->queue ?? "");
+            ))->onQueue($import->queue ?? '');
         }
 
         $jobs->each(function ($job) {

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -70,9 +70,9 @@ class QueuedWriter
             $diskOptions
         ));
 
-        return new PendingDispatch(
+        return (new PendingDispatch(
             (new QueueExport($export, $temporaryFile, $writerType))->chain($jobs->toArray())
-        );
+        ))->onQueue($export->queue);
     }
 
     /**

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -72,7 +72,7 @@ class QueuedWriter
 
         return (new PendingDispatch(
             (new QueueExport($export, $temporaryFile, $writerType))->chain($jobs->toArray())
-        ))->onQueue($export->queue ?? "");
+        ))->onQueue($export->queue ?? '');
     }
 
     /**

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -72,7 +72,7 @@ class QueuedWriter
 
         return (new PendingDispatch(
             (new QueueExport($export, $temporaryFile, $writerType))->chain($jobs->toArray())
-        ))->onQueue($export->queue);
+        ))->onQueue($export->queue ?? "");
     }
 
     /**


### PR DESCRIPTION
…rts/exports

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
This is probably a very minor change but I felt I needed it while working on a project recently and was surprised when it didn't actually work.
Added the ability to specify the queue name in implicit queued imports/exports. This didn't work before but now it works.

```
    ...
    use Queueable, SerializesModels, Exportable, SkipsFailures;
    
    public function __construct()
    {
        $this->onQueue("exports");
    }
    ...
```

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣  Does it include tests, if possible?
No
4️⃣  Any drawbacks? Possible breaking changes?
Most likely not
5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
