### PR TITLE
Match Laravel's named argument.

### DIFF
--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 /**
  * @method static BinaryFileResponse download(object $export, string $fileName, string $writerType = null, array $headers = [])
- * @method static bool store(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+ * @method static bool store(object $export, string $filePath, string $diskName = null, string $writerType = null, $diskOptions = [])
  * @method static PendingDispatch queue(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
  * @method static string raw(object $export, string $writerType)
  * @method static BaseExcel import(object $import, string|UploadedFile $filePath, string $disk = null, string $readerType = null)

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -64,10 +64,10 @@ class ExcelFake implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function store($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function store($export, string $filePath, string $diskName = null, string $writerType = null, $diskOptions = [])
     {
         if ($export instanceof ShouldQueue) {
-            return $this->queue($export, $filePath, $disk, $writerType);
+            return $this->queue($export, $filePath, $diskName, $writerType);
         }
 
         $this->stored[$disk ?? 'default'][$filePath] = $export;


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

So we can use named arguments as stated here:

```
use Maatwebsite\Excel\Facades\Excel;


Excel::store(
			export: new UserComplaintsExcelExport,
			filePath: 'complaints.xlsx',
      diskName: 'local'
			writerType: \Maatwebsite\Excel\Excel::XLSX,
			diskOptions: [
				'lock' => LOCK_NB,
			]
  );
```


4️⃣  Any drawbacks? Possible breaking changes?

Maybe there should be multiple changes in the package.

5️⃣  Mark the following tasks as done:

- [X] Checked the codebase to ensure that your feature doesn't already exist.
- [X] Take note of the contributing guidelines.
- [X] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [ ] Updated the changelog

6️⃣  Thanks for contributing! 🙌
