### PR TITLE
Add multiple sheet support to WithChunkReading (fix #3938)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Bug preventing WithChunkReading from working with multiple sheets when using ToCollection or ToArray   
+
 ## [3.1.47] - 2023-02-16
 
 - Support Laravel 10

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -129,6 +129,10 @@ class ReadChunk implements ShouldQueue
             $this->import->setChunkOffset($this->startRow);
         }
 
+        if (method_exists($this->sheetImport, 'setChunkOffset')) {
+            $this->sheetImport->setChunkOffset($this->startRow);
+        }
+
         if ($this->sheetImport instanceof WithCustomValueBinder) {
             Cell::setValueBinder($this->sheetImport);
         }


### PR DESCRIPTION
**Why should it be added? What are the benefits of this change?**

This change fixes the bug described in #3938 where chunk reading concern would not work correctly when used in an import class (importing multiple sheets) to a collection or an array.

The benefit of this change will be that the chunked reading will work as expected and not be broken when used this way.


**Any drawbacks? Possible breaking change?**

No. The code won't run unless the `setChunkOffset` method exists on the sheetImport instance. Existing implementations will be unaffected as they will have been implemented on the import class which is not impacted. 

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [x] Updated the changelog
