### PR TITLE
sheets() method of WithMultipleSheets to return iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- WithMultipleSheets interface sheets() method return type change to iterable.
+
 ### Fixed
 - Bug preventing WithChunkReading from working with multiple sheets when using ToCollection or ToArray   
 

--- a/src/Concerns/WithMultipleSheets.php
+++ b/src/Concerns/WithMultipleSheets.php
@@ -5,7 +5,7 @@ namespace Maatwebsite\Excel\Concerns;
 interface WithMultipleSheets
 {
     /**
-     * @return array
+     * @return iterable
      */
     public function sheets(): iterable;
 }

--- a/src/Concerns/WithMultipleSheets.php
+++ b/src/Concerns/WithMultipleSheets.php
@@ -7,5 +7,5 @@ interface WithMultipleSheets
     /**
      * @return array
      */
-    public function sheets(): array;
+    public function sheets(): iterable;
 }

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -476,7 +476,7 @@ class WithMultipleSheetsTest extends TestCase
              */
             public function sheets(): iterable
             {
-                foreach(['A', 'B', 'C'] as $a) {
+                foreach (['A', 'B', 'C'] as $a) {
                     yield new SheetWith100Rows($a);
                 }
             }

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -474,7 +474,7 @@ class WithMultipleSheetsTest extends TestCase
             /**
              * @return \Generator
              */
-            public function sheets(): array
+            public function sheets(): iterable
             {
                 foreach(['A', 'B', 'C'] as $a) {
                     yield new SheetWith100Rows($a);

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -461,4 +461,31 @@ class WithMultipleSheetsTest extends TestCase
             $this->assertTrue($sheet->called);
         }
     }
+
+    /**
+     * @test
+     */
+    public function can_export_with_multiple_sheets_using_generators()
+    {
+        $export = new class implements WithMultipleSheets
+        {
+            use Exportable;
+
+            /**
+             * @return \Generator
+             */
+            public function sheets(): array
+            {
+                foreach(['A', 'B', 'C'] as $a) {
+                    yield new SheetWith100Rows($a);
+                }
+            }
+        };
+
+        $export->store('from-view.xlsx');
+
+        $this->assertCount(100, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 0));
+        $this->assertCount(100, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 1));
+        $this->assertCount(100, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 2));
+    }
 }


### PR DESCRIPTION
Changed return type of sheets() method in WithMultipleSheets interface to iterable, so it supports Generators.

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
now sheets() method can also return Generators making it memory safe, if sheets are large.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣  Does it include tests, if possible?
Yes.

4️⃣  Any drawbacks? Possible breaking changes?
No, iterable allows array to be returned, so nothing changed.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
