### PR TITLE
Fix: Row::toArray() respecting end column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Bug preventing WithChunkReading from working with multiple sheets when using ToCollection or ToArray   
+- Row::toArray() now always respects the endColumn
 
 ## [3.1.47] - 2023-02-16
 

--- a/src/Row.php
+++ b/src/Row.php
@@ -43,6 +43,11 @@ class Row implements ArrayAccess
     protected $rowCacheFormatData;
 
     /**
+     * @var string|null
+     */
+    protected $rowCacheEndColumn;
+
+    /**
      * @param  SpreadsheetRow  $row
      * @param  array  $headingRow
      * @param  array  $headerIsGrouped
@@ -83,7 +88,7 @@ class Row implements ArrayAccess
      */
     public function toArray($nullValue = null, $calculateFormulas = false, $formatData = true, ?string $endColumn = null)
     {
-        if (is_array($this->rowCache) && ($this->rowCacheFormatData === $formatData)) {
+        if (is_array($this->rowCache) && ($this->rowCacheFormatData === $formatData) && ($this->rowCacheEndColumn === $endColumn)) {
             return $this->rowCache;
         }
 
@@ -112,6 +117,7 @@ class Row implements ArrayAccess
 
         $this->rowCache           = $cells;
         $this->rowCacheFormatData = $formatData;
+        $this->rowCacheEndColumn  = $endColumn;
 
         return $cells;
     }

--- a/tests/Concerns/OnEachRowTest.php
+++ b/tests/Concerns/OnEachRowTest.php
@@ -44,4 +44,31 @@ class OnEachRowTest extends TestCase
 
         $this->assertEquals(2, $import->called);
     }
+    /**
+     * @test
+     */
+    public function it_respects_the_end_column()
+    {
+        $import = new class implements OnEachRow
+        {
+            use Importable;
+
+            /**
+             * @param  Row  $row
+             */
+            public function onRow(Row $row)
+            {
+                // Accessing a row as an array calls toArray() without an end
+                // column. This saves the row in the cache, so we have to
+                // invalidate the cache once the end column changes
+                $row[0];
+
+                Assert::assertEquals([
+                    'test',
+                ], $row->toArray(null, false, true, 'A'));
+            }
+        };
+
+        $import->import('import.xlsx');
+    }
 }

--- a/tests/Concerns/OnEachRowTest.php
+++ b/tests/Concerns/OnEachRowTest.php
@@ -44,6 +44,7 @@ class OnEachRowTest extends TestCase
 
         $this->assertEquals(2, $import->called);
     }
+
     /**
      * @test
      */


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
See #3946 
2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣  Does it include tests, if possible?
Yes
4️⃣  Any drawbacks? Possible breaking changes?
I guess if somebody provided an endColumn in the past and expected it not to be taken into account, it could break something
5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
