### PR TITLE
fix: wait for all jobs to be completed before running AfterImportJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Bug preventing WithChunkReading from working with multiple sheets when using ToCollection or ToArray   
+- Bug preventing WithChunkReading from working with multiple sheets when using ToCollection or ToArray  
+- Bug that could delete the import file before all the jobs had finished when using WithChunkReading and ShouldQueueWithoutChain
 
 ## [3.1.47] - 2023-02-16
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
   <php>
     <env name="APP_KEY" value="base64:6igsHe3RYC88h3Wje3VzSNqPwUr7Z5ru+NZw/9qwY5M="/>
     <env name="DB_HOST" value="127.0.0.1"/>
@@ -18,4 +14,9 @@
       <directory suffix="Test.php">./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -38,7 +38,7 @@ class ChunkReader
      * @param  WithChunkReading  $import
      * @param  Reader  $reader
      * @param  TemporaryFile  $temporaryFile
-     * @return \Illuminate\Foundation\Bus\PendingDispatch|null
+     * @return PendingDispatch|Collection|null
      */
     public function read(WithChunkReading $import, Reader $reader, TemporaryFile $temporaryFile)
     {
@@ -50,7 +50,6 @@ class ChunkReader
         $totalRows    = $reader->getTotalRows();
         $worksheets   = $reader->getWorksheets($import);
         $queue        = property_exists($import, 'queue') ? $import->queue : null;
-        $delayCleanup = property_exists($import, 'delayCleanup') ? $import->delayCleanup : 600;
 
         if ($import instanceof WithProgressBar) {
             $import->getConsoleOutput()->progressStart(array_sum($totalRows));
@@ -84,7 +83,8 @@ class ChunkReader
         $afterImportJob = new AfterImportJob($import, $reader);
 
         if ($import instanceof ShouldQueueWithoutChain) {
-            $jobs->push($afterImportJob->delay($delayCleanup));
+            $afterImportJob->setDependencies($jobs);
+            $jobs->push($afterImportJob->delay(60));
 
             return $jobs->each(function ($job) use ($queue) {
                 dispatch($job->onQueue($queue));

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -84,6 +84,7 @@ class ChunkReader
         $afterImportJob = new AfterImportJob($import, $reader);
 
         if ($import instanceof ShouldQueueWithoutChain) {
+            $afterImportJob->setInterval($delayCleanup);
             $afterImportJob->setDependencies($jobs);
             $jobs->push($afterImportJob->delay($delayCleanup));
 

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -50,6 +50,7 @@ class ChunkReader
         $totalRows    = $reader->getTotalRows();
         $worksheets   = $reader->getWorksheets($import);
         $queue        = property_exists($import, 'queue') ? $import->queue : null;
+        $delayCleanup = property_exists($import, 'cleanupInterval') ? $import->cleanupInterval : 60;
 
         if ($import instanceof WithProgressBar) {
             $import->getConsoleOutput()->progressStart(array_sum($totalRows));
@@ -84,7 +85,7 @@ class ChunkReader
 
         if ($import instanceof ShouldQueueWithoutChain) {
             $afterImportJob->setDependencies($jobs);
-            $jobs->push($afterImportJob->delay(60));
+            $jobs->push($afterImportJob->delay($delayCleanup));
 
             return $jobs->each(function ($job) use ($queue) {
                 dispatch($job->onQueue($queue));

--- a/src/Jobs/AfterImportJob.php
+++ b/src/Jobs/AfterImportJob.php
@@ -31,6 +31,8 @@ class AfterImportJob implements ShouldQueue
      */
     private $dependencyIds = [];
 
+    private $interval = 60;
+
     /**
      * @param  object  $import
      * @param  Reader  $reader
@@ -39,6 +41,11 @@ class AfterImportJob implements ShouldQueue
     {
         $this->import = $import;
         $this->reader = $reader;
+    }
+
+    public function setInterval(int $interval)
+    {
+        $this->interval = $interval;
     }
 
     public function setDependencies(Collection $jobs)
@@ -54,7 +61,7 @@ class AfterImportJob implements ShouldQueue
             if (!ReadChunk::isComplete($id)) {
                 // Until there is no jobs left to run we put this job back into the queue every minute
                 // Note: this will do nothing in a SyncQueue but that's desired, because in a SyncQueue jobs run in order
-                $this->release(60);
+                $this->release($this->interval);
 
                 return;
             }

--- a/src/Jobs/AfterImportJob.php
+++ b/src/Jobs/AfterImportJob.php
@@ -4,6 +4,8 @@ namespace Maatwebsite\Excel\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\ImportFailed;
 use Maatwebsite\Excel\HasEventBus;
@@ -12,7 +14,7 @@ use Throwable;
 
 class AfterImportJob implements ShouldQueue
 {
-    use Queueable, HasEventBus;
+    use HasEventBus, InteractsWithQueue, Queueable;
 
     /**
      * @var WithEvents
@@ -25,6 +27,11 @@ class AfterImportJob implements ShouldQueue
     private $reader;
 
     /**
+     * @var iterable
+     */
+    private $dependencyIds = [];
+
+    /**
      * @param  object  $import
      * @param  Reader  $reader
      */
@@ -34,8 +41,25 @@ class AfterImportJob implements ShouldQueue
         $this->reader = $reader;
     }
 
+    public function setDependencies(Collection $jobs)
+    {
+        $this->dependencyIds = $jobs->map(function (ReadChunk $job) {
+            return $job->getUniqueId();
+        })->all();
+    }
+
     public function handle()
     {
+        foreach ($this->dependencyIds as $id) {
+            if (!ReadChunk::isComplete($id)) {
+                // Until there is no jobs left to run we put this job back into the queue every minute
+                // Note: this will do nothing in a SyncQueue but that's desired, because in a SyncQueue jobs run in order
+                $this->release(60);
+
+                return;
+            }
+        }
+
         if ($this->import instanceof ShouldQueue && $this->import instanceof WithEvents) {
             $this->reader->clearListeners();
             $this->reader->registerListeners($this->import->registerEvents());

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -211,7 +211,7 @@ class ReadChunk implements ShouldQueue
      */
     public function failed(Throwable $e)
     {
-        $this->cleanUpTempFile();
+        $this->cleanUpTempFile(true);
 
         if ($this->import instanceof WithEvents) {
             $this->registerListeners($this->import->registerEvents());
@@ -223,13 +223,13 @@ class ReadChunk implements ShouldQueue
         }
     }
 
-    private function cleanUpTempFile()
+    private function cleanUpTempFile(bool $force = false): bool
     {
         if (!empty($this->uniqueId)) {
             Cache::delete('laravel-excel/read-chunk/' . $this->uniqueId);
         }
 
-        if (!config('excel.temporary_files.force_resync_remote')) {
+        if (!$force && !config('excel.temporary_files.force_resync_remote')) {
             return true;
         }
 

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -204,10 +204,6 @@ class ReadChunk implements ShouldQueue
 
             $this->cleanUpTempFile();
         });
-
-        if (!empty($this->uniqueId)) {
-            Cache::delete('laravel-excel/read-chunk/' . $this->uniqueId);
-        }
     }
 
     /**
@@ -215,9 +211,7 @@ class ReadChunk implements ShouldQueue
      */
     public function failed(Throwable $e)
     {
-        if ($this->temporaryFile instanceof RemoteTemporaryFile) {
-            $this->temporaryFile->deleteLocalCopy();
-        }
+        $this->cleanUpTempFile();
 
         if ($this->import instanceof WithEvents) {
             $this->registerListeners($this->import->registerEvents());
@@ -231,6 +225,10 @@ class ReadChunk implements ShouldQueue
 
     private function cleanUpTempFile()
     {
+        if (!empty($this->uniqueId)) {
+            Cache::delete('laravel-excel/read-chunk/' . $this->uniqueId);
+        }
+
         if (!config('excel.temporary_files.force_resync_remote')) {
             return true;
         }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -106,7 +106,7 @@ class Reader
         }
 
         try {
-            $this->loadSpreadsheet($import, $this->reader);
+            $this->loadSpreadsheet($import);
 
             ($this->transaction)(function () use ($import) {
                 $sheetsToDisconnect = [];

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -166,7 +166,7 @@ class Writer
         );
 
         $writer->save(
-            $path = $temporaryFile->getLocalPath()
+            $temporaryFile->getLocalPath()
         );
 
         if ($temporaryFile instanceof RemoteTemporaryFile) {

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -105,14 +105,14 @@ class ShouldQueueWithoutChainTest extends TestCase
         self::assertTrue(ReadChunk::isComplete($chunks->first()->getUniqueId()));
         self::assertFalse(ReadChunk::isComplete($chunks->last()->getUniqueId()));
 
-        Event::listen(function (JobProcessed $event) {
+        Event::listen(JobProcessed::class, function (JobProcessed $event) {
             self::assertTrue($event->job->isReleased());
         });
         $fake->push($afterImport);
         Event::forget(JobProcessed::class);
         $fake->push($chunks->last());
 
-        Event::listen(function (JobProcessed $event) {
+        Event::listen(JobProcessed::class, function (JobProcessed $event) {
             self::assertFalse($event->job->isReleased());
         });
         $fake->push($afterImport);

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\SyncQueue;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Maatwebsite\Excel\Jobs\AfterImportJob;
 use Maatwebsite\Excel\Jobs\QueueImport;
@@ -66,5 +69,52 @@ class ShouldQueueWithoutChainTest extends TestCase
 
         Queue::assertPushedOn('queue-name', ReadChunk::class);
         Queue::assertPushedOn('queue-name', AfterImportJob::class);
+    }
+
+    /**
+     * @test
+     */
+    public function the_cleanup_only_runs_when_all_jobs_are_done()
+    {
+        $fake = Queue::fake();
+
+        if (method_exists($fake, 'serializeAndRestore')) {
+            $fake->serializeAndRestore(); // More realism
+        }
+
+        $import = new QueueImportWithoutJobChaining();
+
+        $import->import('import-users.xlsx');
+
+        $jobs   = Queue::pushedJobs();
+        $chunks = collect($jobs[ReadChunk::class])->pluck('job');
+        $chunks->each(function (ReadChunk $chunk) {
+            self::assertFalse(ReadChunk::isComplete($chunk->getUniqueId()));
+        });
+        self::assertCount(2, $chunks);
+        $afterImport = $jobs[AfterImportJob::class][0]['job'];
+
+        if (!method_exists($fake, 'except')) {
+            /** @var SyncQueue $queue */
+            $fake = app(SyncQueue::class);
+        } else {
+            $fake->except([AfterImportJob::class, ReadChunk::class]);
+        }
+        $fake->push($chunks->first());
+        self::assertTrue(ReadChunk::isComplete($chunks->first()->getUniqueId()));
+        self::assertFalse(ReadChunk::isComplete($chunks->last()->getUniqueId()));
+
+        Event::listen(function (JobProcessed $event) {
+            self::assertTrue($event->job->isReleased());
+        });
+        $fake->push($afterImport);
+        Event::forget(JobProcessed::class);
+        $fake->push($chunks->last());
+
+        Event::listen(function (JobProcessed $event) {
+            self::assertFalse($event->job->isReleased());
+        });
+        $fake->push($afterImport);
+        Event::forget(JobProcessed::class);
     }
 }

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -97,6 +97,7 @@ class ShouldQueueWithoutChainTest extends TestCase
         if (!method_exists($fake, 'except')) {
             /** @var SyncQueue $queue */
             $fake = app(SyncQueue::class);
+            $fake->setContainer(app());
         } else {
             $fake->except([AfterImportJob::class, ReadChunk::class]);
         }


### PR DESCRIPTION
fixes #3560

By storing a list of ids in the cache when creating the jobs, that we delete one by one when the job completes, we retry the AfterImportJob every 60 seconds and check that all jobs have completed

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog
