### PR TITLE
Add AfterBatch and AfterChunk event and refactor events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- AfterChunk and AfterBatch events
+
 ### Fixed
 - Bug preventing WithChunkReading from working with multiple sheets when using ToCollection or ToArray   
 

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -14,7 +14,6 @@ use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithLimit;
 use Maatwebsite\Excel\Concerns\WithProgressBar;
-use Maatwebsite\Excel\Events\BeforeImport;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Imports\HeadingRowExtractor;
 use Maatwebsite\Excel\Jobs\AfterImportJob;
@@ -42,7 +41,7 @@ class ChunkReader
      */
     public function read(WithChunkReading $import, Reader $reader, TemporaryFile $temporaryFile)
     {
-        if ($import instanceof WithEvents && isset($import->registerEvents()[BeforeImport::class])) {
+        if ($import instanceof WithEvents) {
             $reader->beforeImport($import);
         }
 

--- a/src/Concerns/RegistersEventListeners.php
+++ b/src/Concerns/RegistersEventListeners.php
@@ -2,6 +2,8 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
+use Maatwebsite\Excel\Events\AfterBatch;
+use Maatwebsite\Excel\Events\AfterChunk;
 use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\AfterSheet;
 use Maatwebsite\Excel\Events\BeforeExport;
@@ -9,6 +11,7 @@ use Maatwebsite\Excel\Events\BeforeImport;
 use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Events\BeforeWriting;
 use Maatwebsite\Excel\Events\ImportFailed;
+use ReflectionClass;
 
 trait RegistersEventListeners
 {
@@ -17,34 +20,27 @@ trait RegistersEventListeners
      */
     public function registerEvents(): array
     {
+        $listenersClasses = [
+            BeforeExport::class,
+            BeforeWriting::class,
+            BeforeImport::class,
+            AfterImport::class,
+            AfterBatch::class,
+            AfterChunk::class,
+            AfterChunk::class,
+            ImportFailed::class,
+            BeforeSheet::class,
+            AfterSheet::class,
+        ];
         $listeners = [];
 
-        if (method_exists($this, 'beforeExport')) {
-            $listeners[BeforeExport::class] = [static::class, 'beforeExport'];
-        }
-
-        if (method_exists($this, 'beforeWriting')) {
-            $listeners[BeforeWriting::class] = [static::class, 'beforeWriting'];
-        }
-
-        if (method_exists($this, 'beforeImport')) {
-            $listeners[BeforeImport::class] = [static::class, 'beforeImport'];
-        }
-
-        if (method_exists($this, 'afterImport')) {
-            $listeners[AfterImport::class] = [static::class, 'afterImport'];
-        }
-
-        if (method_exists($this, 'importFailed')) {
-            $listeners[ImportFailed::class] = [static::class, 'importFailed'];
-        }
-
-        if (method_exists($this, 'beforeSheet')) {
-            $listeners[BeforeSheet::class] = [static::class, 'beforeSheet'];
-        }
-
-        if (method_exists($this, 'afterSheet')) {
-            $listeners[AfterSheet::class] = [static::class, 'afterSheet'];
+        foreach ($listenersClasses as $class) {
+            $name = (new ReflectionClass($class))->getShortName();
+            // Method names are case insensitive in php
+            if (method_exists($this, $name)) {
+                // Allow methods to not be static
+                $listeners[$class] = [$this, $name];
+            }
         }
 
         return $listeners;

--- a/src/Concerns/RegistersEventListeners.php
+++ b/src/Concerns/RegistersEventListeners.php
@@ -21,21 +21,19 @@ trait RegistersEventListeners
     public function registerEvents(): array
     {
         $listenersClasses = [
-            BeforeExport::class,
-            BeforeWriting::class,
-            BeforeImport::class,
-            AfterImport::class,
-            AfterBatch::class,
-            AfterChunk::class,
-            AfterChunk::class,
-            ImportFailed::class,
-            BeforeSheet::class,
-            AfterSheet::class,
+            BeforeExport::class => 'beforeExport',
+            BeforeWriting::class => 'beforeWriting',
+            BeforeImport::class => 'beforeImport',
+            AfterImport::class => 'afterImport',
+            AfterBatch::class => 'afterBatch',
+            AfterChunk::class => 'afterChunk',
+            ImportFailed::class => 'importFailed',
+            BeforeSheet::class => 'beforeSheet',
+            AfterSheet::class => 'afterSheet',
         ];
         $listeners = [];
 
-        foreach ($listenersClasses as $class) {
-            $name = (new ReflectionClass($class))->getShortName();
+        foreach ($listenersClasses as $class => $name) {
             // Method names are case insensitive in php
             if (method_exists($this, $name)) {
                 // Allow methods to not be static

--- a/src/Concerns/RegistersEventListeners.php
+++ b/src/Concerns/RegistersEventListeners.php
@@ -11,7 +11,6 @@ use Maatwebsite\Excel\Events\BeforeImport;
 use Maatwebsite\Excel\Events\BeforeSheet;
 use Maatwebsite\Excel\Events\BeforeWriting;
 use Maatwebsite\Excel\Events\ImportFailed;
-use ReflectionClass;
 
 trait RegistersEventListeners
 {
@@ -21,15 +20,15 @@ trait RegistersEventListeners
     public function registerEvents(): array
     {
         $listenersClasses = [
-            BeforeExport::class => 'beforeExport',
+            BeforeExport::class  => 'beforeExport',
             BeforeWriting::class => 'beforeWriting',
-            BeforeImport::class => 'beforeImport',
-            AfterImport::class => 'afterImport',
-            AfterBatch::class => 'afterBatch',
-            AfterChunk::class => 'afterChunk',
-            ImportFailed::class => 'importFailed',
-            BeforeSheet::class => 'beforeSheet',
-            AfterSheet::class => 'afterSheet',
+            BeforeImport::class  => 'beforeImport',
+            AfterImport::class   => 'afterImport',
+            AfterBatch::class    => 'afterBatch',
+            AfterChunk::class    => 'afterChunk',
+            ImportFailed::class  => 'importFailed',
+            BeforeSheet::class   => 'beforeSheet',
+            AfterSheet::class    => 'afterSheet',
         ];
         $listeners = [];
 

--- a/src/Events/AfterBatch.php
+++ b/src/Events/AfterBatch.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Maatwebsite\Excel\Events;
+
+use Maatwebsite\Excel\Imports\ModelManager;
+
+class AfterBatch extends Event
+{
+    /**
+     * @var ModelManager
+     */
+    public $manager;
+
+    /**
+     * @var int
+     */
+    private $batchSize;
+
+    /**
+     * @var int
+     */
+    private $startRow;
+
+    /**
+     * @param  ModelManager  $manager
+     * @param  object  $importable
+     * @param  int  $batchSize
+     * @param  int  $startRow
+     */
+    public function __construct(ModelManager $manager, $importable, int $batchSize, int $startRow)
+    {
+        $this->manager   = $manager;
+        $this->batchSize = $batchSize;
+        $this->startRow  = $startRow;
+        parent::__construct($importable);
+    }
+
+    public function getManager(): ModelManager
+    {
+        return $this->manager;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDelegate()
+    {
+        return $this->manager;
+    }
+
+    public function getBatchSize(): int
+    {
+        return $this->batchSize;
+    }
+
+    public function getStartRow(): int
+    {
+        return $this->startRow;
+    }
+}

--- a/src/Events/AfterChunk.php
+++ b/src/Events/AfterChunk.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Maatwebsite\Excel\Events;
+
+use Maatwebsite\Excel\Sheet;
+
+class AfterChunk extends Event
+{
+    /**
+     * @var Sheet
+     */
+    private $sheet;
+
+    /**
+     * @var int
+     */
+    private $startRow;
+
+    public function __construct(Sheet $sheet, $importable, int $startRow)
+    {
+        $this->sheet     = $sheet;
+        $this->startRow  = $startRow;
+        parent::__construct($importable);
+    }
+
+    public function getSheet(): Sheet
+    {
+        return $this->sheet;
+    }
+
+    public function getDelegate()
+    {
+        return $this->sheet;
+    }
+
+    public function getStartRow(): int
+    {
+        return $this->startRow;
+    }
+}

--- a/src/Events/AfterImport.php
+++ b/src/Events/AfterImport.php
@@ -12,18 +12,13 @@ class AfterImport extends Event
     public $reader;
 
     /**
-     * @var object
-     */
-    private $importable;
-
-    /**
      * @param  Reader  $reader
      * @param  object  $importable
      */
     public function __construct(Reader $reader, $importable)
     {
         $this->reader     = $reader;
-        $this->importable = $importable;
+        parent::__construct($importable);
     }
 
     /**
@@ -32,14 +27,6 @@ class AfterImport extends Event
     public function getReader(): Reader
     {
         return $this->reader;
-    }
-
-    /**
-     * @return object
-     */
-    public function getConcernable()
-    {
-        return $this->importable;
     }
 
     /**

--- a/src/Events/AfterSheet.php
+++ b/src/Events/AfterSheet.php
@@ -12,18 +12,13 @@ class AfterSheet extends Event
     public $sheet;
 
     /**
-     * @var object
-     */
-    private $exportable;
-
-    /**
      * @param  Sheet  $sheet
      * @param  object  $exportable
      */
     public function __construct(Sheet $sheet, $exportable)
     {
         $this->sheet      = $sheet;
-        $this->exportable = $exportable;
+        parent::__construct($exportable);
     }
 
     /**
@@ -32,14 +27,6 @@ class AfterSheet extends Event
     public function getSheet(): Sheet
     {
         return $this->sheet;
-    }
-
-    /**
-     * @return object
-     */
-    public function getConcernable()
-    {
-        return $this->exportable;
     }
 
     /**

--- a/src/Events/BeforeExport.php
+++ b/src/Events/BeforeExport.php
@@ -12,18 +12,13 @@ class BeforeExport extends Event
     public $writer;
 
     /**
-     * @var object
-     */
-    private $exportable;
-
-    /**
      * @param  Writer  $writer
      * @param  object  $exportable
      */
     public function __construct(Writer $writer, $exportable)
     {
         $this->writer     = $writer;
-        $this->exportable = $exportable;
+        parent::__construct($exportable);
     }
 
     /**
@@ -32,14 +27,6 @@ class BeforeExport extends Event
     public function getWriter(): Writer
     {
         return $this->writer;
-    }
-
-    /**
-     * @return object
-     */
-    public function getConcernable()
-    {
-        return $this->exportable;
     }
 
     /**

--- a/src/Events/BeforeImport.php
+++ b/src/Events/BeforeImport.php
@@ -12,18 +12,13 @@ class BeforeImport extends Event
     public $reader;
 
     /**
-     * @var object
-     */
-    private $importable;
-
-    /**
      * @param  Reader  $reader
      * @param  object  $importable
      */
     public function __construct(Reader $reader, $importable)
     {
         $this->reader     = $reader;
-        $this->importable = $importable;
+        parent::__construct($importable);
     }
 
     /**
@@ -32,14 +27,6 @@ class BeforeImport extends Event
     public function getReader(): Reader
     {
         return $this->reader;
-    }
-
-    /**
-     * @return object
-     */
-    public function getConcernable()
-    {
-        return $this->importable;
     }
 
     /**

--- a/src/Events/BeforeSheet.php
+++ b/src/Events/BeforeSheet.php
@@ -12,18 +12,13 @@ class BeforeSheet extends Event
     public $sheet;
 
     /**
-     * @var object
-     */
-    private $exportable;
-
-    /**
      * @param  Sheet  $sheet
      * @param  object  $exportable
      */
     public function __construct(Sheet $sheet, $exportable)
     {
         $this->sheet       = $sheet;
-        $this->exportable  = $exportable;
+        parent::__construct($exportable);
     }
 
     /**
@@ -32,14 +27,6 @@ class BeforeSheet extends Event
     public function getSheet(): Sheet
     {
         return $this->sheet;
-    }
-
-    /**
-     * @return object
-     */
-    public function getConcernable()
-    {
-        return $this->exportable;
     }
 
     /**

--- a/src/Events/BeforeWriting.php
+++ b/src/Events/BeforeWriting.php
@@ -23,7 +23,7 @@ class BeforeWriting extends Event
     public function __construct(Writer $writer, $exportable)
     {
         $this->writer     = $writer;
-        $this->exportable = $exportable;
+        parent::__construct($exportable);
     }
 
     /**
@@ -32,14 +32,6 @@ class BeforeWriting extends Event
     public function getWriter(): Writer
     {
         return $this->writer;
-    }
-
-    /**
-     * @return object
-     */
-    public function getConcernable()
-    {
-        return $this->exportable;
     }
 
     /**

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -10,7 +10,7 @@ abstract class Event
     /**
      * @var object
      */
-    private $concernable;
+    protected $concernable;
 
     /**
      * @param  object  $concernable

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -2,12 +2,31 @@
 
 namespace Maatwebsite\Excel\Events;
 
+/**
+ * @internal
+ */
 abstract class Event
 {
     /**
+     * @var object
+     */
+    private $concernable;
+
+    /**
+     * @param  object  $concernable
+     */
+    public function __construct($concernable)
+    {
+        $this->concernable = $concernable;
+    }
+
+    /**
      * @return object
      */
-    abstract public function getConcernable();
+    public function getConcernable()
+    {
+        return $this->concernable;
+    }
 
     /**
      * @return mixed

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -7,15 +7,20 @@ use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
 use Maatwebsite\Excel\Concerns\WithCalculatedFormulas;
 use Maatwebsite\Excel\Concerns\WithColumnLimit;
+use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithFormatData;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithProgressBar;
 use Maatwebsite\Excel\Concerns\WithValidation;
+use Maatwebsite\Excel\Events\AfterBatch;
+use Maatwebsite\Excel\HasEventBus;
 use Maatwebsite\Excel\Row;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class ModelImporter
 {
+    use HasEventBus;
+
     /**
      * @var ModelManager
      */
@@ -42,6 +47,9 @@ class ModelImporter
         if ($startRow > $worksheet->getHighestRow()) {
             return;
         }
+        if ($import instanceof WithEvents) {
+            $this->registerListeners($import->registerEvents());
+        }
 
         $headingRow       = HeadingRowExtractor::extract($worksheet, $import);
         $headerIsGrouped  = HeadingRowExtractor::extractGrouping($headingRow, $import);
@@ -56,12 +64,13 @@ class ModelImporter
 
         $this->manager->setRemembersRowNumber(method_exists($import, 'rememberRowNumber'));
 
-        $i = 0;
+        $i             = 0;
+        $batchStartRow = $startRow;
         foreach ($worksheet->getRowIterator($startRow, $endRow) as $spreadSheetRow) {
             $i++;
 
             $row = new Row($spreadSheetRow, $headingRow, $headerIsGrouped);
-            if (!$import instanceof SkipsEmptyRows || ($import instanceof SkipsEmptyRows && !$row->isEmpty($withCalcFormulas))) {
+            if (!$import instanceof SkipsEmptyRows || !$row->isEmpty($withCalcFormulas)) {
                 $rowArray = $row->toArray(null, $withCalcFormulas, $formatData, $endColumn);
 
                 if ($import instanceof SkipsEmptyRows && method_exists($import, 'isEmptyWhen') && $import->isEmptyWhen($rowArray)) {
@@ -83,7 +92,8 @@ class ModelImporter
 
                 // Flush each batch.
                 if (($i % $batchSize) === 0) {
-                    $this->manager->flush($import, $batchSize > 1);
+                    $this->flush($import, $batchSize, $batchStartRow);
+                    $batchStartRow += $i;
                     $i = 0;
 
                     if ($progessBar) {
@@ -93,7 +103,15 @@ class ModelImporter
             }
         }
 
-        // Flush left-overs.
+        if ($i > 0) {
+            // Flush left-overs.
+            $this->flush($import, $batchSize, $batchStartRow);
+        }
+    }
+
+    private function flush(ToModel $import, int $batchSize, int $startRow)
+    {
         $this->manager->flush($import, $batchSize > 1);
+        $this->raise(new AfterBatch($this->manager, $import, $batchSize, $startRow));
     }
 }

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -8,6 +8,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\AfterChunk;
 use Maatwebsite\Excel\Events\ImportFailed;
 use Maatwebsite\Excel\Files\RemoteTemporaryFile;
 use Maatwebsite\Excel\Files\TemporaryFile;
@@ -182,6 +183,8 @@ class ReadChunk implements ShouldQueue
             $sheet->disconnect();
 
             $this->cleanUpTempFile();
+
+            $sheet->raise(new AfterChunk($sheet, $this->import, $this->startRow));
         });
     }
 
@@ -204,7 +207,7 @@ class ReadChunk implements ShouldQueue
         }
     }
 
-    private function cleanUpTempFile()
+    private function cleanUpTempFile(): bool
     {
         if (!config('excel.temporary_files.force_resync_remote')) {
             return true;

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -249,7 +249,6 @@ class Sheet
 
         $calculatesFormulas = $import instanceof WithCalculatedFormulas;
         $formatData         = $import instanceof WithFormatData;
-        $endColumn          = $import instanceof WithColumnLimit ? $import->endColumn() : null;
 
         if ($import instanceof WithMappedCells) {
             app(MappedReader::class)->map($import, $this->worksheet);

--- a/tests/Data/Stubs/ImportWithEvents.php
+++ b/tests/Data/Stubs/ImportWithEvents.php
@@ -21,6 +21,11 @@ class ImportWithEvents implements WithEvents
     /**
      * @var callable
      */
+    public $afterImport;
+
+    /**
+     * @var callable
+     */
     public $beforeSheet;
 
     /**

--- a/tests/Data/Stubs/ImportWithEventsChunksAndBatches.php
+++ b/tests/Data/Stubs/ImportWithEventsChunksAndBatches.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithBatchInserts;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Maatwebsite\Excel\Events\AfterBatch;
+use Maatwebsite\Excel\Events\AfterChunk;
+
+class ImportWithEventsChunksAndBatches extends ImportWithEvents implements WithBatchInserts, ToModel, WithChunkReading
+{
+    /**
+     * @var callable
+     */
+    public $afterBatch;
+
+    /**
+     * @var callable
+     */
+    public $afterChunk;
+
+    /**
+     * @return array
+     */
+    public function registerEvents(): array
+    {
+        return parent::registerEvents() + [
+            AfterBatch::class => $this->afterBatch ?? function () {
+            },
+            AfterChunk::class => $this->afterChunk ?? function () {
+            },
+        ];
+    }
+
+    public function model(array $row)
+    {
+    }
+
+    public function batchSize(): int
+    {
+        return 100;
+    }
+
+    public function chunkSize(): int
+    {
+        return 500;
+    }
+}


### PR DESCRIPTION
- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog


I always want to run things after the flush operation (like running events for each model in the batch) or after a job is finished but not the whole import (for updating cache), but after searching for a while, there is just no way to do that, so I added 2 events that fire in those cases

I also did some minor refactoring of the events since there was a lot of sharing and repeating code