### PR TITLE
Respect isEmptyWhen when using OnEachRow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Bug preventing WithChunkReading from working with multiple sheets when using ToCollection or ToArray   
+- Fixed issue where isEmptyWhen was not being called when using OnEachRow
 
 ## [3.1.47] - 2023-02-16
 

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -292,9 +292,11 @@ class Sheet
                     $sheetRow->setPreparationCallback($preparationCallback);
                 }
 
-                if (!$import instanceof SkipsEmptyRows || ($import instanceof SkipsEmptyRows && !$sheetRow->isEmpty($calculatesFormulas))) {
+                $rowArray                    = $sheetRow->toArray(null, $import instanceof WithCalculatedFormulas, $import instanceof WithFormatData, $endColumn);
+                $rowIsEmptyAccordingToImport = $import instanceof SkipsEmptyRows && method_exists($import, 'isEmptyWhen') && $import->isEmptyWhen($rowArray);
+                if (!$import instanceof SkipsEmptyRows || ($import instanceof SkipsEmptyRows && (!$rowIsEmptyAccordingToImport && !$sheetRow->isEmpty($calculatesFormulas)))) {
                     if ($import instanceof WithValidation) {
-                        $toValidate = [$sheetRow->getIndex() => $sheetRow->toArray(null, $import instanceof WithCalculatedFormulas, $import instanceof WithFormatData, $endColumn)];
+                        $toValidate = [$sheetRow->getIndex() => $rowArray];
 
                         try {
                             app(RowValidator::class)->validate($toValidate, $import);

--- a/tests/Concerns/SkipsEmptyRowsTest.php
+++ b/tests/Concerns/SkipsEmptyRowsTest.php
@@ -165,4 +165,35 @@ class SkipsEmptyRowsTest extends TestCase
         $import->import('skip-empty-rows-with-is-empty-when.xlsx');
         $this->assertTrue($import->called);
     }
+
+    /**
+     * @test
+     */
+    public function custom_skips_rows_when_using_oneachrow()
+    {
+        $import = new class implements SkipsEmptyRows, OnEachRow
+        {
+            use Importable;
+
+            public $called = false;
+
+            /**
+             * @param  array  $row
+             */
+            public function onRow(Row $row)
+            {
+                Assert::assertEquals('Not empty', $row[0]);
+            }
+
+            public function isEmptyWhen(array $row): bool
+            {
+                $this->called = true;
+
+                return $row[0] === 'Empty';
+            }
+        };
+
+        $import->import('skip-empty-rows-with-is-empty-when.xlsx');
+        $this->assertTrue($import->called);
+    }
 }


### PR DESCRIPTION


Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

Previously isEmptyWhen was not being called when using the OnEachRow concern. This was not clear from the documentation and I don't think there's a deliberate reason not to call `isEmptyWhen` in this scenario.

I've based my logic on the existing code for the `ToArray` concern.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣  Does it include tests, if possible?

Yes.

4️⃣  Any drawbacks? Possible breaking changes?

No.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [x] Updated the changelog

6️⃣  Thanks for contributing! 🙌
