### PR TITLE
Fix facade diskName

### DIFF
--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 /**
  * @method static BinaryFileResponse download(object $export, string $fileName, string $writerType = null, array $headers = [])
- * @method static bool store(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+ * @method static bool store(object $export, string $filePath, string $diskName = null, string $writerType = null, $diskOptions = [])
  * @method static PendingDispatch queue(object $export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
  * @method static string raw(object $export, string $writerType)
  * @method static BaseExcel import(object $import, string|UploadedFile $filePath, string $disk = null, string $readerType = null)


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
Currently the facade has an incorrect PHPDoc stating that the `store` method of `Excel.php` accepts the `$disk` argument while it actually accepts the `$diskName` argument. This causes confusing behaviour, for example incorrect IDE autocompletion or PHPStan errors

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
No

4️⃣  Any drawbacks? Possible breaking changes?
No breaking change.

A drawback is that other methods in Excel.php use `$disk` instead of `$diskName`, so using `$disk` instead of `$diskName` would be more consistent, but that would be a breaking change. Using `$diskName` everywhere would make the most sense, since we're not receiving an instance of a Disk, but that would be an even bigger breaking change I think.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
yw :)