### PR TITLE
Update composer OR in constraints to use newer double pipe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     "ext-json": "*",
     "php": "^7.0||^8.0",
     "phpoffice/phpspreadsheet": "^1.18",
-    "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0",
-    "psr/simple-cache": "^1.0|^2.0|^3.0",
+    "illuminate/support": "5.8.*||^6.0||^7.0||^8.0||^9.0||^10.0",
+    "psr/simple-cache": "^1.0||^2.0||^3.0",
     "composer/semver": "^3.3"
   },
   "require-dev": {
-    "orchestra/testbench": "^6.0|^7.0|^8.0",
+    "orchestra/testbench": "^6.0||^7.0||^8.0",
     "predis/predis": "^1.1"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": "^7.0|^8.0",
+    "php": "^7.0||^8.0",
     "phpoffice/phpspreadsheet": "^1.18",
     "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0",
     "psr/simple-cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
I was unable to `composer require maatwebsite/excel:^3.1` with Composer version 2.6.1 and PHP 8.2.10 getting "maatwebsite/excel 3.1.0 requires php ^7.0 -> your php version (8.2.10) does not satisfy that requirement" with the single pipe.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
N/A

4️⃣  Any drawbacks? Possible breaking changes?
This is the latest and should not break anything

5️⃣  Mark the following tasks as done:

- [x ] Checked the codebase to ensure that your feature doesn't already exist.
- [x ] Take note of the contributing guidelines.
- [x ] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
