### PR TITLE
Laravel Scout support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,22 +29,22 @@ jobs:
         os: [ubuntu-latest]
         include:
           - laravel: 10
-            scout: 10
+            scout: 10.*
             testbench: 8.*
           - laravel: 9
-            scout: 9
+            scout: 9.*
             testbench: 7.*
           - laravel: 8
-            scout: 8
+            scout: 8.*
             testbench: 6.*
           - laravel: 7
-            scout: 7
+            scout: 7.2.*
             testbench: 5.*
           - laravel: 6
-            scout: 7
+            scout: 7.1.*
             testbench: 4.*
           - laravel: 5.8
-            scout: 7
+            scout: 7.1.*
             testbench: 3.8.*
         exclude:
           - laravel: 10

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" "laravel/scout:${{ matrix.testbench }}"  --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" "laravel/scout:${{ matrix.laravel }}"  --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --no-interaction
 
       - name: Install legacy factories

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,16 +29,22 @@ jobs:
         os: [ubuntu-latest]
         include:
           - laravel: 10
+            scout: 10
             testbench: 8.*
           - laravel: 9
+            scout: 9
             testbench: 7.*
           - laravel: 8
+            scout: 8
             testbench: 6.*
           - laravel: 7
+            scout: 7
             testbench: 5.*
           - laravel: 6
+            scout: 7
             testbench: 4.*
           - laravel: 5.8
+            scout: 7
             testbench: 3.8.*
         exclude:
           - laravel: 10
@@ -93,7 +99,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" "laravel/scout:${{ matrix.laravel }}"  --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" "laravel/scout:${{ matrix.scout }}"  --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --no-interaction
 
       - name: Install legacy factories

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}"  --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" "laravel/scout:${{ matrix.testbench }}"  --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --no-interaction
 
       - name: Install legacy factories

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,7 @@
   },
   "require-dev": {
     "orchestra/testbench": "^6.0||^7.0||^8.0",
-    "predis/predis": "^1.1",
-    "laravel/scout": "5.8.*||^6.0||^7.0||^8.0||^9.0||^10.0",
-    "laravel/legacy-factories": "^1.3"
+    "predis/predis": "^1.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,9 @@
   },
   "require-dev": {
     "orchestra/testbench": "^6.0||^7.0||^8.0",
-    "predis/predis": "^1.1"
+    "predis/predis": "^1.1",
+    "laravel/scout": "5.8.*||^6.0||^7.0||^8.0||^9.0||^10.0",
+    "laravel/legacy-factories": "^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/src/Concerns/FromQuery.php
+++ b/src/Concerns/FromQuery.php
@@ -5,11 +5,12 @@ namespace Maatwebsite\Excel\Concerns;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
+use Laravel\Scout\Builder as ScoutBuilder;
 
 interface FromQuery
 {
     /**
-     * @return Builder|EloquentBuilder|Relation
+     * @return Builder|EloquentBuilder|Relation|ScoutBuilder
      */
     public function query();
 }

--- a/src/Jobs/AppendPaginatedToSheet.php
+++ b/src/Jobs/AppendPaginatedToSheet.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Maatwebsite\Excel\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder;
+use Laravel\Scout\Builder as ScoutBuilder;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Files\TemporaryFile;
+use Maatwebsite\Excel\Jobs\Middleware\LocalizeJob;
+use Maatwebsite\Excel\Writer;
+
+class AppendPaginatedToSheet implements ShouldQueue
+{
+    use Queueable, Dispatchable, ProxyFailures, InteractsWithQueue;
+
+    /**
+     * @var TemporaryFile
+     */
+    public $temporaryFile;
+
+    /**
+     * @var string
+     */
+    public $writerType;
+
+    /**
+     * @var int
+     */
+    public $sheetIndex;
+
+    /**
+     * @var FromQuery
+     */
+    public $sheetExport;
+
+    /**
+     * @var int
+     */
+    public $page;
+
+    /**
+     * @var int
+     */
+    public $perPage;
+
+    /**
+     * @param  FromQuery  $sheetExport
+     * @param  TemporaryFile  $temporaryFile
+     * @param  string  $writerType
+     * @param  int  $sheetIndex
+     * @param  int  $page
+     * @param  int  $perPage
+     */
+    public function __construct(
+        FromQuery $sheetExport,
+        TemporaryFile $temporaryFile,
+        string $writerType,
+        int $sheetIndex,
+        int $page,
+        int $perPage
+    ) {
+        $this->sheetExport   = $sheetExport;
+        $this->temporaryFile = $temporaryFile;
+        $this->writerType    = $writerType;
+        $this->sheetIndex    = $sheetIndex;
+        $this->page          = $page;
+        $this->perPage       = $perPage;
+    }
+
+    /**
+     * Get the middleware the job should be dispatched through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return (method_exists($this->sheetExport, 'middleware')) ? $this->sheetExport->middleware() : [];
+    }
+
+    /**
+     * @param  Writer  $writer
+     *
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
+     */
+    public function handle(Writer $writer)
+    {
+        (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer) {
+            $writer = $writer->reopen($this->temporaryFile, $this->writerType);
+
+            $sheet = $writer->getSheetByIndex($this->sheetIndex);
+
+            $sheet->appendRows($this->chunk($this->sheetExport->query()), $this->sheetExport);
+
+            $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
+        });
+    }
+
+    /**
+     * @param  Builder|Relation|EloquentBuilder|ScoutBuilder  $query
+     */
+    protected function chunk($query)
+    {
+        if ($query instanceof \Laravel\Scout\Builder) {
+            return $query->paginate($this->perPage, 'page', $this->page)->items();
+        } else {
+            return $query->forPage($this->page, $this->perPage)->get();
+        }
+    }
+}

--- a/src/Jobs/AppendPaginatedToSheet.php
+++ b/src/Jobs/AppendPaginatedToSheet.php
@@ -4,11 +4,11 @@ namespace Maatwebsite\Excel\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
 use Laravel\Scout\Builder as ScoutBuilder;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Files\TemporaryFile;

--- a/src/Jobs/AppendPaginatedToSheet.php
+++ b/src/Jobs/AppendPaginatedToSheet.php
@@ -109,8 +109,9 @@ class AppendPaginatedToSheet implements ShouldQueue
     {
         if ($query instanceof \Laravel\Scout\Builder) {
             return $query->paginate($this->perPage, 'page', $this->page)->items();
-        } else {
-            return $query->forPage($this->page, $this->perPage)->get();
         }
+
+        // Fallback
+        return $query->forPage($this->page, $this->perPage)->get();
     }
 }

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -13,6 +13,7 @@ use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Files\TemporaryFileFactory;
 use Maatwebsite\Excel\Jobs\AppendDataToSheet;
+use Maatwebsite\Excel\Jobs\AppendPaginatedToSheet;
 use Maatwebsite\Excel\Jobs\AppendQueryToSheet;
 use Maatwebsite\Excel\Jobs\AppendViewToSheet;
 use Maatwebsite\Excel\Jobs\CloseSheet;
@@ -150,6 +151,10 @@ class QueuedWriter
     ): Collection {
         $query = $export->query();
 
+        if ($query instanceof \Laravel\Scout\Builder) {
+            return $this->exportScout($export, $temporaryFile, $writerType, $sheetIndex);
+        }
+
         $count = $export instanceof WithCustomQuerySize ? $export->querySize() : $query->count();
         $spins = ceil($count / $this->getChunkSize($export));
 
@@ -157,6 +162,46 @@ class QueuedWriter
 
         for ($page = 1; $page <= $spins; $page++) {
             $jobs->push(new AppendQueryToSheet(
+                $export,
+                $temporaryFile,
+                $writerType,
+                $sheetIndex,
+                $page,
+                $this->getChunkSize($export)
+            ));
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * @param  FromQuery  $export
+     * @param  TemporaryFile  $temporaryFile
+     * @param  string  $writerType
+     * @param  int  $sheetIndex
+     * @return Collection
+     */
+    private function exportScout(
+        FromQuery $export,
+        TemporaryFile $temporaryFile,
+        string        $writerType,
+        int           $sheetIndex
+    ): Collection {
+        $jobs = new Collection();
+
+        $chunk = $export->query()->paginate($this->getChunkSize($export));
+        // Append first page
+        $jobs->push(new AppendDataToSheet(
+            $export,
+            $temporaryFile,
+            $writerType,
+            $sheetIndex,
+            $chunk->items()
+        ));
+
+        // Append rest of pages
+        for ($page = 2; $page <= $chunk->lastPage(); $page++) {
+            $jobs->push(new AppendPaginatedToSheet(
                 $export,
                 $temporaryFile,
                 $writerType,

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -184,8 +184,8 @@ class QueuedWriter
     private function exportScout(
         FromQuery $export,
         TemporaryFile $temporaryFile,
-        string        $writerType,
-        int           $sheetIndex
+        string $writerType,
+        int $sheetIndex
     ): Collection {
         $jobs = new Collection();
 

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -464,9 +464,32 @@ class Sheet
      */
     public function fromQuery(FromQuery $sheetExport, Worksheet $worksheet)
     {
-        $sheetExport->query()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
-            $this->appendRows($chunk, $sheetExport);
-        });
+        if ($sheetExport->query() instanceof \Laravel\Scout\Builder) {
+            $this->fromScout($sheetExport, $worksheet);
+        } else {
+            $sheetExport->query()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
+                $this->appendRows($chunk, $sheetExport);
+            });
+        }
+    }
+
+    /**
+     * @param  FromQuery  $sheetExport
+     * @param  Worksheet  $worksheet
+     */
+    public function fromScout(FromQuery $sheetExport, Worksheet $worksheet)
+    {
+        $scout = $sheetExport->query();
+        $chunkSize = $this->getChunkSize($sheetExport);
+
+        $chunk = $scout->paginate($chunkSize);
+        // Append first page
+        $this->appendRows($chunk->items(), $sheetExport);
+
+        // Append rest of pages
+        for ($page = 2; $page <= $chunk->lastPage(); $page++) {
+            $this->appendRows($scout->paginate($chunkSize, 'page', $page)->items(), $sheetExport);
+        }
     }
 
     /**

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -466,11 +466,12 @@ class Sheet
     {
         if ($sheetExport->query() instanceof \Laravel\Scout\Builder) {
             $this->fromScout($sheetExport, $worksheet);
-        } else {
-            $sheetExport->query()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
-                $this->appendRows($chunk, $sheetExport);
-            });
+            return;
         }
+
+        $sheetExport->query()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
+            $this->appendRows($chunk, $sheetExport);
+        });
     }
 
     /**

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -466,6 +466,7 @@ class Sheet
     {
         if ($sheetExport->query() instanceof \Laravel\Scout\Builder) {
             $this->fromScout($sheetExport, $worksheet);
+
             return;
         }
 

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -479,7 +479,7 @@ class Sheet
      */
     public function fromScout(FromQuery $sheetExport, Worksheet $worksheet)
     {
-        $scout = $sheetExport->query();
+        $scout     = $sheetExport->query();
         $chunkSize = $this->getChunkSize($sheetExport);
 
         $chunk = $scout->paginate($chunkSize);

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -256,6 +256,7 @@ class FromQueryTest extends TestCase
     {
         if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
             $this->markTestSkipped('Laravel Scout is too old');
+
             return;
         }
 

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -11,6 +11,7 @@ use Maatwebsite\Excel\Tests\Data\Stubs\FromNonEloquentQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExportWithEagerLoad;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExportWithPrepareRows;
+use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersScoutExport;
 use Maatwebsite\Excel\Tests\TestCase;
 
 class FromQueryTest extends TestCase
@@ -266,5 +267,25 @@ class FromQueryTest extends TestCase
         }
 
         return $expected;
+    }
+
+    /**
+     * @test
+     */
+    public function can_export_from_scout()
+    {
+        $export = new FromUsersScoutExport;
+
+        $response = $export->store('from-scout-store.xlsx');
+
+        $this->assertTrue($response);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-scout-store.xlsx', 'Xlsx');
+
+        $allUsers = $export->query()->get()->map(function (User $user) {
+            return array_values($user->toArray());
+        })->toArray();
+
+        $this->assertEquals($allUsers, $contents);
     }
 }

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -275,11 +275,11 @@ class FromQueryTest extends TestCase
      */
     public function can_export_from_scout()
     {
-        $export = new FromUsersScoutExport;
-
-        if ($export->query() instanceof NullEngine) {
+        if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
             $this->markTestSkipped('Laravel Scout is too old');
         } else {
+
+            $export = new FromUsersScoutExport;
 
             $response = $export->store('from-scout-store.xlsx');
 

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Support\Facades\DB;
-use Laravel\Scout\Engines\NullEngine;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromGroupUsersQueuedQueryExport;
@@ -150,7 +149,7 @@ class FromQueryTest extends TestCase
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-without-eloquent.xlsx', 'Xlsx');
 
         $allUsers = $export->query()->get()->map(function ($row) {
-            return array_values((array)$row);
+            return array_values((array) $row);
         })->all();
 
         $this->assertEquals($allUsers, $contents);
@@ -168,7 +167,7 @@ class FromQueryTest extends TestCase
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-without-eloquent.xlsx', 'Xlsx');
 
         $allUsers = $export->query()->get()->map(function ($row) {
-            return array_values((array)$row);
+            return array_values((array) $row);
         })->all();
 
         $this->assertEquals($allUsers, $contents);
@@ -250,26 +249,6 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    protected function format_nested_arrays_expected_data($groups)
-    {
-        $expected = [];
-        foreach ($groups as $group) {
-            $group_row = [$group->name, ''];
-
-            foreach ($group->users as $key => $user) {
-                if ($key === 0) {
-                    $group_row[1] = $user->email;
-                    $expected[] = $group_row;
-                    continue;
-                }
-
-                $expected[] = ['', $user->email];
-            }
-        }
-
-        return $expected;
-    }
-
     /**
      * @test
      */
@@ -278,7 +257,6 @@ class FromQueryTest extends TestCase
         if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
             $this->markTestSkipped('Laravel Scout is too old');
         } else {
-
             $export = new FromUsersScoutExport;
 
             $response = $export->store('from-scout-store.xlsx');
@@ -293,5 +271,25 @@ class FromQueryTest extends TestCase
 
             $this->assertEquals($allUsers, $contents);
         }
+    }
+
+    protected function format_nested_arrays_expected_data($groups)
+    {
+        $expected = [];
+        foreach ($groups as $group) {
+            $group_row = [$group->name, ''];
+
+            foreach ($group->users as $key => $user) {
+                if ($key === 0) {
+                    $group_row[1] = $user->email;
+                    $expected[]   = $group_row;
+                    continue;
+                }
+
+                $expected[] = ['', $user->email];
+            }
+        }
+
+        return $expected;
     }
 }

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Support\Facades\DB;
+use Laravel\Scout\Engines\NullEngine;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromGroupUsersQueuedQueryExport;
@@ -149,7 +150,7 @@ class FromQueryTest extends TestCase
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-without-eloquent.xlsx', 'Xlsx');
 
         $allUsers = $export->query()->get()->map(function ($row) {
-            return array_values((array) $row);
+            return array_values((array)$row);
         })->all();
 
         $this->assertEquals($allUsers, $contents);
@@ -167,7 +168,7 @@ class FromQueryTest extends TestCase
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-without-eloquent.xlsx', 'Xlsx');
 
         $allUsers = $export->query()->get()->map(function ($row) {
-            return array_values((array) $row);
+            return array_values((array)$row);
         })->all();
 
         $this->assertEquals($allUsers, $contents);
@@ -258,7 +259,7 @@ class FromQueryTest extends TestCase
             foreach ($group->users as $key => $user) {
                 if ($key === 0) {
                     $group_row[1] = $user->email;
-                    $expected[]   = $group_row;
+                    $expected[] = $group_row;
                     continue;
                 }
 
@@ -276,16 +277,21 @@ class FromQueryTest extends TestCase
     {
         $export = new FromUsersScoutExport;
 
-        $response = $export->store('from-scout-store.xlsx');
+        if ($export->query() instanceof NullEngine) {
+            $this->markTestSkipped('Laravel Scout is too old');
+        } else {
 
-        $this->assertTrue($response);
+            $response = $export->store('from-scout-store.xlsx');
 
-        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-scout-store.xlsx', 'Xlsx');
+            $this->assertTrue($response);
 
-        $allUsers = $export->query()->get()->map(function (User $user) {
-            return array_values($user->toArray());
-        })->toArray();
+            $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-scout-store.xlsx', 'Xlsx');
 
-        $this->assertEquals($allUsers, $contents);
+            $allUsers = $export->query()->get()->map(function (User $user) {
+                return array_values($user->toArray());
+            })->toArray();
+
+            $this->assertEquals($allUsers, $contents);
+        }
     }
 }

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -256,21 +256,22 @@ class FromQueryTest extends TestCase
     {
         if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
             $this->markTestSkipped('Laravel Scout is too old');
-        } else {
-            $export = new FromUsersScoutExport;
-
-            $response = $export->store('from-scout-store.xlsx');
-
-            $this->assertTrue($response);
-
-            $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-scout-store.xlsx', 'Xlsx');
-
-            $allUsers = $export->query()->get()->map(function (User $user) {
-                return array_values($user->toArray());
-            })->toArray();
-
-            $this->assertEquals($allUsers, $contents);
+            return;
         }
+
+        $export = new FromUsersScoutExport;
+
+        $response = $export->store('from-scout-store.xlsx');
+
+        $this->assertTrue($response);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-scout-store.xlsx', 'Xlsx');
+
+        $allUsers = $export->query()->get()->map(function (User $user) {
+            return array_values($user->toArray());
+        })->toArray();
+
+        $this->assertEquals($allUsers, $contents);
     }
 
     protected function format_nested_arrays_expected_data($groups)

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -4,9 +4,14 @@ namespace Maatwebsite\Excel\Tests\Data\Stubs\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Laravel\Scout\Engines\DatabaseEngine;
+use Laravel\Scout\Engines\Engine;
+use Laravel\Scout\Searchable;
 
 class User extends Model
 {
+    use Searchable;
+
     /**
      * @var array
      */
@@ -30,5 +35,10 @@ class User extends Model
     public function groups(): BelongsToMany
     {
         return $this->belongsToMany(Group::class);
+    }
+
+    public function searchableUsing(): Engine
+    {
+        return new DatabaseEngine();
     }
 }

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -8,6 +8,8 @@ use Laravel\Scout\Engines\DatabaseEngine;
 use Laravel\Scout\Engines\Engine;
 use Laravel\Scout\Engines\NullEngine;
 use Laravel\Scout\Searchable;
+use Maatwebsite\Excel\Tests\Concerns\FromQueryTest;
+use Maatwebsite\Excel\Tests\QueuedQueryExportTest;
 
 class User extends Model
 {
@@ -38,6 +40,18 @@ class User extends Model
         return $this->belongsToMany(Group::class);
     }
 
+    /**
+     * Laravel Scout under <=8 provides only
+     * — NullEngine, that is searches nothing and not applicable for tests and
+     * — AlgoliaEngine, that is 3-d party dependent and not applicable for tests too
+     *
+     * The only test-ready engine is DatabaseEngine that comes with Scout >8
+     *
+     * Then running tests we will examine engine and skip test until DatabaseEngine is provided.
+     *
+     * @see QueuedQueryExportTest::can_queue_scout_export()
+     * @see FromQueryTest::can_export_from_scout()
+     */
     public function searchableUsing(): Engine
     {
         return class_exists('\Laravel\Scout\Engines\DatabaseEngine') ? new DatabaseEngine() : new NullEngine();

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -5,6 +5,7 @@ namespace Maatwebsite\Excel\Tests\Data\Stubs\Database;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Laravel\Scout\Engines\DatabaseEngine;
+use Laravel\Scout\Engines\NullEngine;
 use Laravel\Scout\Engines\Engine;
 use Laravel\Scout\Searchable;
 
@@ -39,6 +40,6 @@ class User extends Model
 
     public function searchableUsing(): Engine
     {
-        return new DatabaseEngine();
+        return class_exists('\Laravel\Scout\Engines\DatabaseEngine') ? new DatabaseEngine() : new NullEngine();
     }
 }

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -43,7 +43,7 @@ class User extends Model
     /**
      * Laravel Scout under <=8 provides only
      * — NullEngine, that is searches nothing and not applicable for tests and
-     * — AlgoliaEngine, that is 3-d party dependent and not applicable for tests too
+     * — AlgoliaEngine, that is 3-d party dependent and not applicable for tests too.
      *
      * The only test-ready engine is DatabaseEngine that comes with Scout >8
      *

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -5,8 +5,8 @@ namespace Maatwebsite\Excel\Tests\Data\Stubs\Database;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Laravel\Scout\Engines\DatabaseEngine;
-use Laravel\Scout\Engines\NullEngine;
 use Laravel\Scout\Engines\Engine;
+use Laravel\Scout\Engines\NullEngine;
 use Laravel\Scout\Searchable;
 
 class User extends Model

--- a/tests/Data/Stubs/FromUsersScoutExport.php
+++ b/tests/Data/Stubs/FromUsersScoutExport.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder;
+use Laravel\Scout\Builder as ScoutBuilder;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+
+class FromUsersScoutExport implements FromQuery, WithCustomChunkSize
+{
+    use Exportable;
+
+    /**
+     * @return Builder|EloquentBuilder|Relation|ScoutBuilder
+     */
+    public function query()
+    {
+        return new ScoutBuilder(new User, '');
+    }
+
+    /**
+     * @return int
+     */
+    public function chunkSize(): int
+    {
+        return 10;
+    }
+}

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -92,11 +92,11 @@ class QueuedQueryExportTest extends TestCase
      */
     public function can_queue_scout_export()
     {
-        $export = new FromUsersScoutExport();
-
-        if ($export->query() instanceof NullEngine) {
+        if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
             $this->markTestSkipped('Laravel Scout is too old');
         } else {
+
+            $export = new FromUsersScoutExport();
 
             $export->queue('queued-scout-export.xlsx')->chain([
                 new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx'),

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -7,6 +7,7 @@ use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExportWithMapping;
+use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersScoutExport;
 
 class QueuedQueryExportTest extends TestCase
 {
@@ -83,5 +84,24 @@ class QueuedQueryExportTest extends TestCase
         // Only 1 column when using map()
         $this->assertCount(1, $actual[0]);
         $this->assertEquals(User::value('name'), $actual[0][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function can_queue_scout_export()
+    {
+        $export = new FromUsersScoutExport();
+
+        $export->queue('queued-scout-export.xlsx')->chain([
+            new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx'),
+        ]);
+
+        $actual = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx', 'Xlsx');
+
+        $this->assertCount(100, $actual);
+
+        // 6 of the 7 columns in export, excluding the "hidden" password column.
+        $this->assertCount(6, $actual[0]);
     }
 }

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests;
 
-use Laravel\Scout\Engines\NullEngine;
 use Maatwebsite\Excel\SettingsProvider;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
@@ -95,7 +94,6 @@ class QueuedQueryExportTest extends TestCase
         if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
             $this->markTestSkipped('Laravel Scout is too old');
         } else {
-
             $export = new FromUsersScoutExport();
 
             $export->queue('queued-scout-export.xlsx')->chain([

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -93,19 +93,20 @@ class QueuedQueryExportTest extends TestCase
     {
         if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
             $this->markTestSkipped('Laravel Scout is too old');
-        } else {
-            $export = new FromUsersScoutExport();
-
-            $export->queue('queued-scout-export.xlsx')->chain([
-                new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx'),
-            ]);
-
-            $actual = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx', 'Xlsx');
-
-            $this->assertCount(100, $actual);
-
-            // 6 of the 7 columns in export, excluding the "hidden" password column.
-            $this->assertCount(6, $actual[0]);
+            return;
         }
+
+        $export = new FromUsersScoutExport();
+
+        $export->queue('queued-scout-export.xlsx')->chain([
+            new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx'),
+        ]);
+
+        $actual = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx', 'Xlsx');
+
+        $this->assertCount(100, $actual);
+
+        // 6 of the 7 columns in export, excluding the "hidden" password column.
+        $this->assertCount(6, $actual[0]);
     }
 }

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -93,6 +93,7 @@ class QueuedQueryExportTest extends TestCase
     {
         if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
             $this->markTestSkipped('Laravel Scout is too old');
+
             return;
         }
 

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Tests;
 
+use Laravel\Scout\Engines\NullEngine;
 use Maatwebsite\Excel\SettingsProvider;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
@@ -93,15 +94,20 @@ class QueuedQueryExportTest extends TestCase
     {
         $export = new FromUsersScoutExport();
 
-        $export->queue('queued-scout-export.xlsx')->chain([
-            new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx'),
-        ]);
+        if ($export->query() instanceof NullEngine) {
+            $this->markTestSkipped('Laravel Scout is too old');
+        } else {
 
-        $actual = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx', 'Xlsx');
+            $export->queue('queued-scout-export.xlsx')->chain([
+                new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx'),
+            ]);
 
-        $this->assertCount(100, $actual);
+            $actual = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-scout-export.xlsx', 'Xlsx');
 
-        // 6 of the 7 columns in export, excluding the "hidden" password column.
-        $this->assertCount(6, $actual[0]);
+            $this->assertCount(100, $actual);
+
+            // 6 of the 7 columns in export, excluding the "hidden" password column.
+            $this->assertCount(6, $actual[0]);
+        }
     }
 }


### PR DESCRIPTION
This PR brings support of `Laravel\Scout\Builder` to `FromQuery` concern.

Users not infrequently want to export their search results. Laravel Scout is a good instrument for searching.

```php
namespace App\Exports;

use App\Invoice;
use Maatwebsite\Excel\Concerns\FromQuery;

class InvoicesExport implements FromQuery
{
    public function query()
    {
        return Invoice::search('Search phrase');
    }
}
```

I write tests — for queued and direct writer.

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
