### PR TITLE
Add AfterChunk event for chunked exports

### DIFF
--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -7,13 +7,15 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\AfterChunk;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Jobs\Middleware\LocalizeJob;
 use Maatwebsite\Excel\Writer;
 
 class AppendQueryToSheet implements ShouldQueue
 {
-    use Queueable, Dispatchable, ProxyFailures, InteractsWithQueue;
+    use Queueable, Dispatchable, ProxyFailures, InteractsWithQueue, HasEventBus;
 
     /**
      * @var TemporaryFile
@@ -88,6 +90,11 @@ class AppendQueryToSheet implements ShouldQueue
     public function handle(Writer $writer)
     {
         (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer) {
+
+            if ($this->sheetExport instanceof WithEvents) {
+                $this->registerListeners($this->sheetExport->registerEvents());
+            }
+            
             $writer = $writer->reopen($this->temporaryFile, $this->writerType);
 
             $sheet = $writer->getSheetByIndex($this->sheetIndex);
@@ -97,6 +104,9 @@ class AppendQueryToSheet implements ShouldQueue
             $sheet->appendRows($query->get(), $this->sheetExport);
 
             $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
+
+            $this->raise(new AfterChunk($sheet, $this->sheetExport, $this->page * $this->chunkSize));
+            $this->clearListeners();
         });
     }
 }

--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -10,6 +10,7 @@ use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\AfterChunk;
 use Maatwebsite\Excel\Files\TemporaryFile;
+use Maatwebsite\Excel\HasEventBus;
 use Maatwebsite\Excel\Jobs\Middleware\LocalizeJob;
 use Maatwebsite\Excel\Writer;
 

--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -90,11 +90,10 @@ class AppendQueryToSheet implements ShouldQueue
     public function handle(Writer $writer)
     {
         (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer) {
-
             if ($this->sheetExport instanceof WithEvents) {
                 $this->registerListeners($this->sheetExport->registerEvents());
             }
-            
+
             $writer = $writer->reopen($this->temporaryFile, $this->writerType);
 
             $sheet = $writer->getSheetByIndex($this->sheetIndex);

--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -105,7 +105,7 @@ class AppendQueryToSheet implements ShouldQueue
 
             $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
 
-            $this->raise(new AfterChunk($sheet, $this->sheetExport, $this->page * $this->chunkSize));
+            $this->raise(new AfterChunk($sheet, $this->sheetExport, ($this->page - 1) * $this->chunkSize));
             $this->clearListeners();
         });
     }

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -76,9 +76,9 @@ class WithEventsTest extends TestCase
     {
         $this->loadLaravelMigrations(['--database' => 'testing']);
         User::query()->create([
-            'name' => $this->faker->name,
-            'email' => $this->faker->unique()->safeEmail,
-            'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
+            'name'           => $this->faker->name,
+            'email'          => $this->faker->unique()->safeEmail,
+            'password'       => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
             'remember_token' => Str::random(10),
         ]);
         $export = new ExportWithEventsChunks();

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -30,8 +30,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class WithEventsTest extends TestCase
 {
-
     use WithFaker;
+
     /**
      * @test
      */

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -2,6 +2,8 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Str;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Events\AfterBatch;
 use Maatwebsite\Excel\Events\AfterChunk;
@@ -17,7 +19,9 @@ use Maatwebsite\Excel\Sheet;
 use Maatwebsite\Excel\Tests\Data\Stubs\BeforeExportListener;
 use Maatwebsite\Excel\Tests\Data\Stubs\CustomConcern;
 use Maatwebsite\Excel\Tests\Data\Stubs\CustomSheetConcern;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\Data\Stubs\ExportWithEvents;
+use Maatwebsite\Excel\Tests\Data\Stubs\ExportWithEventsChunks;
 use Maatwebsite\Excel\Tests\Data\Stubs\ImportWithEvents;
 use Maatwebsite\Excel\Tests\Data\Stubs\ImportWithEventsChunksAndBatches;
 use Maatwebsite\Excel\Tests\TestCase;
@@ -26,6 +30,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class WithEventsTest extends TestCase
 {
+
+    use WithFaker;
     /**
      * @test
      */
@@ -61,6 +67,22 @@ class WithEventsTest extends TestCase
 
         $this->assertInstanceOf(BinaryFileResponse::class, $event->download('filename.xlsx'));
         $this->assertEquals(4, $eventsTriggered);
+    }
+
+    /**
+     * @test
+     */
+    public function export_chunked_events_get_called()
+    {
+        $this->loadLaravelMigrations(['--database' => 'testing']);
+        User::query()->create([
+            'name' => $this->faker->name,
+            'email' => $this->faker->unique()->safeEmail,
+            'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
+            'remember_token' => Str::random(10),
+        ]);
+        $export = new ExportWithEventsChunks();
+        $export->queue('filename.xlsx');
     }
 
     /**

--- a/tests/Data/Stubs/ExportWithEventsChunks.php
+++ b/tests/Data/Stubs/ExportWithEventsChunks.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Builder;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\AfterChunk;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use PHPUnit\Framework\Assert;
+
+class ExportWithEventsChunks implements WithEvents, FromQuery, ShouldQueue, WithCustomChunkSize
+{
+    use Exportable;
+
+    public bool $after = false;
+
+    public function registerEvents(): array
+    {
+        return [
+            AfterChunk::class => function (AfterChunk $event) {
+                Assert::assertInstanceOf(ExportWithEventsChunks::class, $event->getConcernable());
+            },
+        ];
+    }
+
+    public function query(): Builder
+    {
+        return User::query();
+    }
+
+    public function chunkSize(): int
+    {
+        return 1;
+    }
+}

--- a/tests/Data/Stubs/ExportWithEventsChunks.php
+++ b/tests/Data/Stubs/ExportWithEventsChunks.php
@@ -16,8 +16,6 @@ class ExportWithEventsChunks implements WithEvents, FromQuery, ShouldQueue, With
 {
     use Exportable;
 
-    public bool $after = false;
-
     public function registerEvents(): array
     {
         return [


### PR DESCRIPTION
fixes #3606

Add AfterChunk event for chunked exports

This PR allows the AfterChunk event to fire on chunked queued exports.

https://github.com/SpartnerNL/Laravel-Excel/pull/3634

1️⃣  Why should it be added? What are the benefits of this change?

With this, it is possible to
- showing the progress to the user
- estimate time for an export

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣  Does it include tests, if possible?

No

4️⃣  Any drawbacks? Possible breaking changes?

No breaking changes.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [ ] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
