### PR TITLE
Fix mkdir exception

### DIFF
--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -46,7 +46,7 @@ class TemporaryFileFactory
      */
     public function makeLocal(string $fileName = null, string $fileExtension = null): LocalTemporaryFile
     {
-        if (!file_exists($this->temporaryPath) && !mkdir($concurrentDirectory = $this->temporaryPath, config('excel.temporary_files.local_permissions.dir', 0777)) && !is_dir($concurrentDirectory)) {
+        if (!file_exists($this->temporaryPath) && !mkdir($concurrentDirectory = $this->temporaryPath, config('excel.temporary_files.local_permissions.dir', 0777, true)) && !is_dir($concurrentDirectory)) {
             throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
         }
 


### PR DESCRIPTION
Add a third flag to the `mkdir` function to allow it to create root folder if they are not present

1️⃣  Why should it be added? What are the benefits of this change?
Because if the `cache` folder is not present inside the `storage/framework` path then the script throws an unhandled exception and does not create the necessary folders

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
Not required

4️⃣  Any drawbacks? Possible breaking changes?
No

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
