### PR TITLE
Memory exhaust 1024M in queued export with FromQuery method

### DIFF
--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -142,14 +142,14 @@ class QueuedWriter
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $writerType
      * @param  int  $sheetIndex
-     * @return Collection|LazyCollection
+     * @return Collection
      */
     private function exportQuery(
         FromQuery $export,
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex
-    ) {
+    ):Collection {
         $query = $export->query();
 
         if ($query instanceof \Laravel\Scout\Builder) {

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -111,14 +111,14 @@ class QueuedWriter
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $writerType
      * @param  int  $sheetIndex
-     * @return Collection
+     * @return Collection|LazyCollection
      */
     private function exportCollection(
         FromCollection $export,
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex
-    ): Collection {
+    ) {
         return $export
             ->collection()
             ->chunk($this->getChunkSize($export))

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -4,6 +4,7 @@ namespace Maatwebsite\Excel;
 
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\FromView;
@@ -140,14 +141,14 @@ class QueuedWriter
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $writerType
      * @param  int  $sheetIndex
-     * @return Collection
+     * @return Collection|LazyCollection
      */
     private function exportQuery(
         FromQuery $export,
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex
-    ): Collection {
+    ) {
         $query = $export->query();
 
         $count = $export instanceof WithCustomQuerySize ? $export->querySize() : $query->count();

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -149,7 +149,7 @@ class QueuedWriter
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex
-    ):Collection {
+    ): Collection {
         $query = $export->query();
 
         if ($query instanceof \Laravel\Scout\Builder) {

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -66,7 +66,7 @@ class FromCollectionTest extends TestCase
 
         $this->assertEquals(
             $export->collection()->map(
-                function(array $item) {
+                function (array $item) {
                     return array_values($item);
                 }
             )->toArray(),

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -2,6 +2,9 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
+use Illuminate\Foundation\Bus\PendingDispatch;
+use Maatwebsite\Excel\Tests\Data\Stubs\EloquentLazyCollectionExport;
+use Maatwebsite\Excel\Tests\Data\Stubs\FromGroupUsersQueuedQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\SheetWith100Rows;
 use Maatwebsite\Excel\Tests\TestCase;
@@ -46,5 +49,28 @@ class FromCollectionTest extends TestCase
             $this->assertEquals($sheet->collection()->toArray(), $worksheet->toArray());
             $this->assertEquals($sheet->title(), $worksheet->getTitle());
         }
+    }
+
+    /**
+     * @test
+     */
+    public function can_export_from_lazy_collection()
+    {
+        $export = new EloquentLazyCollectionExport();
+
+        $response = $export->queue('from-lazy-collection-store.xlsx');
+
+        $this->assertTrue($response instanceof PendingDispatch);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-lazy-collection-store.xlsx', 'Xlsx');
+
+        $this->assertEquals(
+            $export->collection()->map(
+                function(array $item) {
+                    return array_values($item);
+                }
+            )->toArray(),
+            $contents
+        );
     }
 }

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -4,7 +4,6 @@ namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Maatwebsite\Excel\Tests\Data\Stubs\EloquentLazyCollectionExport;
-use Maatwebsite\Excel\Tests\Data\Stubs\FromGroupUsersQueuedQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\SheetWith100Rows;
 use Maatwebsite\Excel\Tests\TestCase;

--- a/tests/Data/Stubs/EloquentLazyCollectionExport.php
+++ b/tests/Data/Stubs/EloquentLazyCollectionExport.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\LazyCollection;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromCollection;
+
+class EloquentLazyCollectionExport implements FromCollection, ShouldQueue
+{
+    use Exportable;
+
+    public function collection(): LazyCollection
+    {
+        return collect([
+            [
+                'firstname' => 'Patrick',
+                'lastname'  => 'Brouwers',
+            ],
+            [
+                'firstname' => 'Patrick',
+                'lastname'  => 'Brouwers',
+            ],
+            [
+                'firstname' => 'Patrick',
+                'lastname'  => 'Brouwers',
+            ],
+            [
+                'firstname' => 'Patrick',
+                'lastname'  => 'Brouwers',
+            ],
+        ])->lazy();
+    }
+}


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

Please refer ticket #2209 

In order to use `LazyCollection` in a `FromCollection` export, we need to expand the return type of the `QueuedWriter` class. Since we can't use union types due the support of older PHP version, we need to remove the return type, and do it via doc blocks again.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣  Does it include tests, if possible?

No

4️⃣  Any drawbacks? Possible breaking changes?

No

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
