### PR TITLE
Use regex lazy quantifier to match first occurrence in combined validation rules

### DIFF
--- a/src/Validators/RowValidator.php
+++ b/src/Validators/RowValidator.php
@@ -134,7 +134,7 @@ class RowValidator
             return $rules;
         }
 
-        if (Str::contains($rules, 'required_') && preg_match('/(.*):(.*),(.*)/', $rules, $matches)) {
+        if (Str::contains($rules, 'required_') && preg_match('/(.*?):(.*),(.*)/', $rules, $matches)) {
             $column = Str::startsWith($matches[2], '*.') ? $matches[2] : '*.' . $matches[2];
 
             return $matches[1] . ':' . $column . ',' . $matches[3];


### PR DESCRIPTION
Fix rules formatting to use regex **lazy quantifier**(`?`) so that only the first occurrence in combined validation rules is being matched for the prepend of array wildcard(`*`) validation character to the column name.

1️⃣  Why should it be added? What are the benefits of this change?
To fix the `Database connection [3] not configured.` error when using combined validation rules that contain more than 1 colon(`:`).

For example: 
```php
'required_with:mobile_no|nullable|unique:users,user_name|numeric'
```

After `RowValidator::formatRule()` call, the result becomes:
```php
'required_with:mobile_no|nullable|unique:*.users,user_name|numeric'
```

In Laravel validation, `unique:*.users` means specifying a custom database connection:
https://laravel.com/docs/8.x/validation#rule-unique which is not the expected behaviour. Since no database connection is defined, the following error will be returned by Laravel validation:

```
Database connection [3] not configured.
``` 

This fix will output the expected format:
```php
'required_with:*.mobile_no|nullable|unique:users,user_name|numeric'
```

The wildcard(`*`) character is added to the right place.

Reported issues:
- #3834 
- #3748
- #2992 
- #2991 

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣  Does it include tests, if possible?
Not required.

4️⃣  Any drawbacks? Possible breaking changes?
No.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
Welcome.