### PR TITLE
Add a helper for quickly exporting without creating export for a model

### DIFF
--- a/src/Helpers/GenericQueryExport.php
+++ b/src/Helpers/GenericQueryExport.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Maatwebsite\Excel\Helpers;
+
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+
+class GenericQueryExport implements FromQuery, WithHeadings, WithMapping
+{
+    use Exportable;
+
+    /**
+     * @var \Illuminate\Database\Query\Builder
+     */
+    private $_query;
+
+    /**
+     * @var array<string>
+     */
+    private $_headings;
+
+    /**
+     * @var callable
+     */
+    private $_mappings;
+
+    /**
+     * forQuery
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param array $headings
+     * @param callable|null $mappings
+     */
+    public function __construct($query, $headings = [], $mappings = null)
+    {
+        $this->_query = $query;
+        $this->_headings = $headings;
+        if ($mappings) {
+            $this->_mappings = $mappings;
+        }
+    }
+
+    public function headings(): array
+    {
+        return array_values($this->_headings);
+    }
+
+    public function map($row): array
+    {
+        if ($this->_mappings) {
+            return call_user_func($this->_mappings, $row);
+        } elseif ($this->_headings) {
+            $mapping = [];
+            foreach ($this->_headings as $k => $_) {
+                $v = $row;
+                foreach (explode('.', $k) as $k2) {
+                    $v = $v[$k2] ?? null;
+                }
+                $mapping[] = $v;
+            }
+            return array_values($mapping);
+        }
+        return (array) $row;
+    }
+
+    /**
+    * @return \Illuminate\Database\Query\Builder
+    */
+    public function query()
+    {
+        return $this->_query;
+    }
+}

--- a/src/Helpers/GenericQueryExport.php
+++ b/src/Helpers/GenericQueryExport.php
@@ -2,8 +2,8 @@
 
 namespace Maatwebsite\Excel\Helpers;
 
-use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 
@@ -27,14 +27,15 @@ class GenericQueryExport implements FromQuery, WithHeadings, WithMapping
     private $_mappings;
 
     /**
-     * forQuery
-     * @param \Illuminate\Database\Query\Builder $query
-     * @param array $headings
-     * @param callable|null $mappings
+     * forQuery.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $headings
+     * @param  callable|null  $mappings
      */
     public function __construct($query, $headings = [], $mappings = null)
     {
-        $this->_query = $query;
+        $this->_query    = $query;
         $this->_headings = $headings;
         if ($mappings) {
             $this->_mappings = $mappings;
@@ -65,8 +66,8 @@ class GenericQueryExport implements FromQuery, WithHeadings, WithMapping
     }
 
     /**
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function query()
     {
         return $this->_query;

--- a/src/Helpers/GenericQueryExport.php
+++ b/src/Helpers/GenericQueryExport.php
@@ -60,8 +60,10 @@ class GenericQueryExport implements FromQuery, WithHeadings, WithMapping
                 }
                 $mapping[] = $v;
             }
+
             return array_values($mapping);
         }
+
         return (array) $row;
     }
 


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
Allows to quickly export from a controller without creating the export specific to a model/query. E.g.,
```
$query = Comment::with('post')->where('user_id', auth()->user()->id);
$headings = [
  'post.title' => 'Post Name',
  'content' => 'Comment',
  'created_at' => 'Date/Time',
];
return Excel::download(
  new GenericQueryExport($query, $headings),
  'activities.csv',
  \Maatwebsite\Excel\Excel::CSV
);
```

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
No

4️⃣  Any drawbacks? Possible breaking changes?
Makes assumptions about relations already included in the query, and single header row

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
