### PR TITLE
Add ability to specify the file name with a method when using the Exportable concern

### DIFF
--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -20,9 +20,12 @@ trait Exportable
     public function download(string $fileName = null, string $writerType = null, array $headers = null)
     {
         $headers    = $headers ?? $this->headers ?? [];
-        $fileName   = $fileName ?? $this->fileName ?? null;
         $writerType = $writerType ?? $this->writerType ?? null;
 
+        if (method_exists($this, 'getFileName')) {
+            $fileName = $fileName ?? $this->getFileName();
+        }
+        $fileName = $fileName ?? $this->fileName ?? null;
         if (null === $fileName) {
             throw new NoFilenameGivenException();
         }

--- a/tests/Concerns/ExportableTest.php
+++ b/tests/Concerns/ExportableTest.php
@@ -81,6 +81,21 @@ class ExportableTest extends TestCase
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
     }
 
+    public function test_can_set_file_name_via_method()
+    {
+        $export   = new class
+        {
+            use Exportable;
+
+            private function getFileName()
+            {
+                return 'name.csv';
+            }
+        };
+        $response = $export->download();
+        $this->assertEquals('attachment; filename=name.csv', $response->headers->get('Content-Disposition'));
+    }
+
     public function test_can_have_customized_header()
     {
         $export   = new class


### PR DESCRIPTION
This PR provides a way to define the file name to be used by the Exportable concern with a method (instead of an attribute).

1️⃣  Why should it be added? What are the benefits of this change?

Currently, it is possible to set a file name to be used by the Exportable trait, by setting a `$fileName` attribute.

In my experience, however, the name of the file usually depends on some attribute of the export class: e.g., I might want to export all the articles in a year, and call the file "articles2024.csv". I cannot currently do that unless I specify the file name in each method call (e.g., `(new ArticlesExport)->download('articles2024.xlsx')`), which is not ideal since it results in duplication if it needs to be done in different places.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣  Does it include tests, if possible?

Yes.

4️⃣  Any drawbacks? Possible breaking changes?

No breaking changes: if the `getFileName()` method is not present, it will fall back to the `$fileName` attribute.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌

My pleasure!
If you believe that it would be more in line to this package's style to have a `WithFileName` interface to identify when the `getFileName()` method should be use, I can rewrite it in this way.