### PR TITLE
Change filePath to real path if it's an upload

### DIFF
--- a/src/Files/TemporaryFile.php
+++ b/src/Files/TemporaryFile.php
@@ -53,8 +53,10 @@ abstract class TemporaryFile
     public function copyFrom($filePath, string $disk = null): TemporaryFile
     {
         if ($filePath instanceof UploadedFile) {
-            $readStream = fopen($filePath->getRealPath(), 'rb');
-        } elseif ($disk === null && realpath($filePath) !== false) {
+            $filePath = $filePath->getRealPath();
+        }
+
+        if ($disk === null && realpath($filePath) !== false) {
             $readStream = fopen($filePath, 'rb');
         } else {
             $diskInstance = app('filesystem')->disk($disk);


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
The current state breaks cases where the `UploadedFile` is not on a local disk such as S3. I discovered this issue in a project when using S3 for Livewire temporary files. Currently, one must do `$myImport->import($uploadedFile->getRealPath())` instead of `$myImport->import($uploadedFile)` when using S3 for temporary files.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣  Does it include tests, if possible?
No. I'm not sure how to add tests for this without a remote disk connection. If there's a way let me know!

4️⃣  Any drawbacks? Possible breaking changes?
There shouldn't be. It's a small change and for local `UploadFile` instances it should work exactly as it did before.

5️⃣  Mark the following tasks as done:

- [X] Checked the codebase to ensure that your feature doesn't already exist.
- [X] Take note of the contributing guidelines.
- [X] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
Thank you for building an awesome package!
