### PR TITLE
Added withSkipDuplicates import concern

### DIFF
--- a/src/Concerns/WithSkipDuplicates.php
+++ b/src/Concerns/WithSkipDuplicates.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithSkipDuplicates
+{
+}

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\PersistRelations;
 use Maatwebsite\Excel\Concerns\SkipsOnError;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithSkipDuplicates;
 use Maatwebsite\Excel\Concerns\WithUpsertColumns;
 use Maatwebsite\Excel\Concerns\WithUpserts;
 use Maatwebsite\Excel\Concerns\WithValidation;
@@ -123,6 +124,10 @@ class ModelManager
                          );
 
                          return;
+                     } elseif ($import instanceof WithSkipDuplicates) {
+                         $model::query()->insertOrIgnore($models->toArray());
+
+                         return;
                      }
 
                      $model::query()->insert($models->toArray());
@@ -149,6 +154,10 @@ class ModelManager
                                 $import instanceof WithUpsertColumns ? $import->upsertColumns() : null
                             );
 
+                            return;
+                        } elseif ($import instanceof WithSkipDuplicates) {
+                            $model::query()->insertOrIgnore([ $model->getAttributes() ]);
+   
                             return;
                         }
 

--- a/tests/Concerns/WithSkipDuplicatesTest.php
+++ b/tests/Concerns/WithSkipDuplicatesTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithBatchInserts;
+use Maatwebsite\Excel\Concerns\WithSkipDuplicates;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use Maatwebsite\Excel\Tests\TestCase;
+
+class WithSkipDuplicatesTest extends TestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadLaravelMigrations(['--database' => 'testing']);
+    }
+
+    public function test_can_skip_duplicate_models_in_batches()
+    {
+        User::create([
+            'name'      => 'Funny Banana',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
+        ]);
+
+        DB::connection()->enableQueryLog();
+
+        $import = new class implements ToModel, WithBatchInserts, WithSkipDuplicates
+        {
+            use Importable;
+
+            /**
+             * @param  array  $row
+             * @return Model|null
+             */
+            public function model(array $row)
+            {
+                return new User([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @return string|array
+             */
+            public function uniqueBy()
+            {
+                return 'email';
+            }
+
+            /**
+             * @return int
+             */
+            public function batchSize(): int
+            {
+                return 2;
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(1, DB::getQueryLog());
+        DB::connection()->disableQueryLog();
+
+        $this->assertDatabaseHas('users', [
+            'name'      => 'Funny Banana',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'name'      => 'Taylor Otwell',
+            'email'     => 'taylor@laravel.com',
+            'password'  => 'secret',
+        ]);
+
+        $this->assertEquals(2, User::count());
+    }
+
+    public function test_can_skip_duplicate_models_in_rows()
+    {
+        User::create([
+            'name'      => 'Funny Potato',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
+        ]);
+
+        DB::connection()->enableQueryLog();
+
+        $import = new class implements ToModel, WithSkipDuplicates
+        {
+            use Importable;
+
+            /**
+             * @param  array  $row
+             * @return Model|Model[]|null
+             */
+            public function model(array $row)
+            {
+                return new User([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @return string|array
+             */
+            public function uniqueBy()
+            {
+                return 'email';
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(2, DB::getQueryLog());
+        DB::connection()->disableQueryLog();
+
+        $this->assertDatabaseHas('users', [
+            'name'      => 'Funny Potato',
+            'email'     => 'patrick@maatwebsite.nl',
+            'password'  => 'password',
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'name'      => 'Taylor Otwell',
+            'email'     => 'taylor@laravel.com',
+            'password'  => 'secret',
+        ]);
+
+        $this->assertEquals(2, User::count());
+    }
+}


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
Allow skipping duplicate rows on single and batch inserts using `insertOrIgnore` method. Good for use cases where files could be imported multiple times and only a simple duplicate check is needed. In my project i had some quality and performance issues when using upsert for this use case.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
Yes

4️⃣  Any drawbacks? Possible breaking changes?
No

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.