### PR TITLE
[3.x] Add `Macroable` to `Excel` and `ExcelFake`

### DIFF
--- a/src/Excel.php
+++ b/src/Excel.php
@@ -5,13 +5,14 @@ namespace Maatwebsite\Excel;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\Macroable;
 use Maatwebsite\Excel\Files\Filesystem;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Helpers\FileTypeDetector;
 
 class Excel implements Exporter, Importer
 {
-    use RegistersCustomConcerns;
+    use Macroable, RegistersCustomConcerns;
 
     const XLSX     = 'Xlsx';
 

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Traits\Macroable;
 use Maatwebsite\Excel\Exporter;
 use Maatwebsite\Excel\Importer;
 use Maatwebsite\Excel\Reader;
@@ -16,6 +17,8 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ExcelFake implements Exporter, Importer
 {
+    use Macroable;
+
     /**
      * @var array
      */


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
I want to create a custom assertion on `ExcelFake` to make it easier to test a certain thing. Adding it as a macro is easier than copy/pasting the code everywhere and prettier than creating a custom class / trait.

Also added it to `Excel` while I was at it.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
No, not necessary. `Macroable` is tested by Laravel

4️⃣  Any drawbacks? Possible breaking changes?
No

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
