### PR TITLE
Default CSV import file encoding to be guessed

### DIFF
--- a/config/excel.php
+++ b/config/excel.php
@@ -1,6 +1,7 @@
 <?php
 
 use Maatwebsite\Excel\Excel;
+use PhpOffice\PhpSpreadsheet\Reader\Csv;
 
 return [
     'exports' => [
@@ -127,7 +128,7 @@ return [
             'enclosure'        => '"',
             'escape_character' => '\\',
             'contiguous'       => false,
-            'input_encoding'   => 'UTF-8',
+            'input_encoding'   => Csv::GUESS_ENCODING,
         ],
 
         /*


### PR DESCRIPTION
Default the CSV import file encoding in the `config/excel.php` to be guessed by the underlying PhpSpreadsheet library.

Source: https://github.com/PHPOffice/PhpSpreadsheet/blob/bc0460d9b371e59dcd7e5bc0aa81158219e66bc4/src/PhpSpreadsheet/Reader/Csv.php#L17

**Why should it be added? What are the benefits of this change?**
This helps fix issues where importing a file, encoded in ISO-8859-1 instead of the config default of UTF-8 for example, causes accent characters in `José` to be given back as `Jos�`.

Using a default that "guesses" remove most encoding issues and save developers a ton of time. They won't have to do "fixes" like this:
https://github.com/SpartnerNL/Laravel-Excel/issues/3295#issuecomment-885765633

**Does it include tests, if possible?**
Haven't looked through the codebase yet to discover if additional test coverage is needed/desired. What do you think?

**Any drawbacks? Possible breaking changes?**
For those who have published the config file, no drawbacks. If for some reason the "guess" detection fails, PhpSpreadsheet uses the self::DEFAULT_FALLBACK_ENCODING of `CP1252`, but that is assuming that it would fail to detect a UTF-8 file as UTF-8. So you would be using some crazy encoding in that case anyway.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [waiting] Added tests to ensure against regression.
