### PR TITLE
Fix import when using disk

### DIFF
--- a/src/Files/TemporaryFile.php
+++ b/src/Files/TemporaryFile.php
@@ -53,11 +53,13 @@ abstract class TemporaryFile
     public function copyFrom($filePath, string $disk = null): TemporaryFile
     {
         if ($filePath instanceof UploadedFile) {
-            $filePath = $filePath->getRealPath();
+            $realPath = $filePath->getRealPath();
+        } else {
+            $realPath = realpath($filePath);
         }
 
-        if ($disk === null && realpath($filePath) !== false) {
-            $readStream = fopen($filePath, 'rb');
+        if ($realPath !== false) {
+            $readStream = fopen($realPath, 'rb');
         } else {
             $diskInstance = app('filesystem')->disk($disk);
 

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -2,6 +2,8 @@
 
 namespace Maatwebsite\Excel\Tests;
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
@@ -237,6 +239,16 @@ class ExcelTest extends TestCase
 
         $contents = file_get_contents(__DIR__ . '/Data/Disks/Local/import.xlsx');
 
+        if (InstalledVersions::satisfies(new VersionParser, 'illuminate/support', '>=6.0')) {
+            $uploadedFile = UploadedFile::fake()->createWithContent('import.xlsx', $contents);
+        } else {
+            $uploadedFile = UploadedFile::fake()->create('import.xlsx');
+
+            $resource = fopen($uploadedFile->getRealPath(), 'w');
+
+            fwrite($resource, $contents);
+        }
+
         $this->assertEquals(
             new Collection([
                 new Collection([
@@ -244,7 +256,7 @@ class ExcelTest extends TestCase
                     new Collection(['test', 'test']),
                 ]),
             ]),
-            $import->toCollection(UploadedFile::fake()->createWithContent('import.xlsx', $contents), 'local')
+            $import->toCollection($uploadedFile, 'local')
         );
     }
 

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -228,6 +228,26 @@ class ExcelTest extends TestCase
         ]), $import->toCollection('import.xlsx'));
     }
 
+    public function test_can_import_a_simple_xlsx_file_to_collection_with_local_disk()
+    {
+        $import = new class
+        {
+            use Importable;
+        };
+
+        $contents = file_get_contents(__DIR__ . '/Data/Disks/Local/import.xlsx');
+
+        $this->assertEquals(
+            new Collection([
+                new Collection([
+                    new Collection(['test', 'test']),
+                    new Collection(['test', 'test']),
+                ]),
+            ]),
+            $import->toCollection(UploadedFile::fake()->createWithContent('import.xlsx', $contents), 'local')
+        );
+    }
+
     public function test_can_import_a_simple_xlsx_file_to_collection_without_import_object()
     {
         $this->assertEquals(new Collection([


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
Fix bug introduced in "3.1.56" version from PR: https://github.com/SpartnerNL/Laravel-Excel/pull/4132

When importing when a `disk` and `UploadedFile` it was attempting to read from the storage with the absolute file path.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No 

3️⃣  Does it include tests, if possible?
Yes

4️⃣  Any drawbacks? Possible breaking changes?
No

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
