### PR TITLE
Exclude heading row when limiting imported rows

### DIFF
--- a/src/Factories/ReaderFactory.php
+++ b/src/Factories/ReaderFactory.php
@@ -4,6 +4,7 @@ namespace Maatwebsite\Excel\Factories;
 
 use Maatwebsite\Excel\Concerns\MapsCsvSettings;
 use Maatwebsite\Excel\Concerns\WithCustomCsvSettings;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
 use Maatwebsite\Excel\Concerns\WithLimit;
 use Maatwebsite\Excel\Concerns\WithReadFilter;
 use Maatwebsite\Excel\Concerns\WithStartRow;
@@ -61,8 +62,16 @@ class ReaderFactory
         if ($import instanceof WithReadFilter) {
             $reader->setReadFilter($import->readFilter());
         } elseif ($import instanceof WithLimit) {
+            $startRow = 1;
+
+            if ($import instanceof WithStartRow) {
+                $startRow = $import->startRow();
+            } elseif ($import instanceof WithHeadingRow) {
+                $startRow = 2;
+            }
+
             $reader->setReadFilter(new LimitFilter(
-                $import instanceof WithStartRow ? $import->startRow() : 1,
+                $startRow,
                 $import->limit()
             ));
         }

--- a/tests/Concerns/WithLimitTest.php
+++ b/tests/Concerns/WithLimitTest.php
@@ -116,7 +116,12 @@ class WithLimitTest extends TestCase
              */
             public function array(array $array)
             {
-                Assert::assertCount(1, $array);
+                Assert::assertEquals([
+                    [
+                        'Patrick Brouwers',
+                        'patrick@maatwebsite.nl',
+                    ],
+                ], $array);
             }
 
             /**

--- a/tests/Concerns/WithLimitTest.php
+++ b/tests/Concerns/WithLimitTest.php
@@ -105,7 +105,7 @@ class WithLimitTest extends TestCase
         $import->import('import-users.xlsx');
     }
 
-    public function test_can_import_with_heading_row()
+    public function test_can_import_single_with_heading_row()
     {
         $import = new class implements ToArray, WithLimit, WithHeadingRow
         {
@@ -130,6 +130,41 @@ class WithLimitTest extends TestCase
             public function limit(): int
             {
                 return 1;
+            }
+        };
+
+        $import->import('import-users-with-headings.xlsx');
+    }
+
+    public function test_can_import_multiple_with_heading_row()
+    {
+        $import = new class implements ToArray, WithLimit, WithHeadingRow
+        {
+            use Importable;
+
+            /**
+             * @param  array  $array
+             */
+            public function array(array $array)
+            {
+                Assert::assertEquals([
+                    [
+                        'Patrick Brouwers',
+                        'patrick@maatwebsite.nl',
+                    ],
+                    [
+                        'Taylor Otwell',
+                        'taylor@laravel.com',
+                    ],
+                ], $array);
+            }
+
+            /**
+             * @return int
+             */
+            public function limit(): int
+            {
+                return 2;
             }
         };
 

--- a/tests/Concerns/WithLimitTest.php
+++ b/tests/Concerns/WithLimitTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
 use Maatwebsite\Excel\Concerns\WithLimit;
 use Maatwebsite\Excel\Concerns\WithStartRow;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
@@ -102,6 +103,32 @@ class WithLimitTest extends TestCase
         };
 
         $import->import('import-users.xlsx');
+    }
+
+    public function test_can_import_with_heading_row()
+    {
+        $import = new class implements ToArray, WithLimit, WithHeadingRow
+        {
+            use Importable;
+
+            /**
+             * @param  array  $array
+             */
+            public function array(array $array)
+            {
+                Assert::assertCount(1, $array);
+            }
+
+            /**
+             * @return int
+             */
+            public function limit(): int
+            {
+                return 1;
+            }
+        };
+
+        $import->import('import-users-with-headings.xlsx');
     }
 
     public function test_can_set_limit_bigger_than_row_size()


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

This fixes #3439, which occurred because the heading row is included in `LimitFilter` by setting 1 as the starting row, which is the heading row when the `WithHeadingRow` concern is used.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No. The PR only contains 1 commit.

3️⃣  Does it include tests, if possible?

Yes.

4️⃣  Any drawbacks? Possible breaking changes?

Some projects might rely on the current behavior. For example, they might add 1 to their desired limit and ignore the empty row. With this PR, that row could now have data which shouldn't be imported.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
