### PR TITLE
Avoid calling query() twice by adding a local var, fixes #4133 and #4140

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -472,7 +472,11 @@ class Sheet
             return;
         }
 
-        $query->clone()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
+        //Operate on a clone to avoid altering the original
+        //and use the clone operator directly to support old versions of Laravel
+        //that don't have a clone method in eloquent
+        $clonedQuery = clone $query;
+        $clonedQuery->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
             $this->appendRows($chunk, $sheetExport);
         });
     }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -465,13 +465,14 @@ class Sheet
      */
     public function fromQuery(FromQuery $sheetExport, Worksheet $worksheet)
     {
-        if ($sheetExport->query() instanceof \Laravel\Scout\Builder) {
+        $query = $sheetExport->query();
+        if ($query instanceof \Laravel\Scout\Builder) {
             $this->fromScout($sheetExport, $worksheet);
 
             return;
         }
 
-        $sheetExport->query()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
+        $query->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
             $this->appendRows($chunk, $sheetExport);
         });
     }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -472,7 +472,7 @@ class Sheet
             return;
         }
 
-        $query->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
+        $query->clone()->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
             $this->appendRows($chunk, $sheetExport);
         });
     }

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -11,6 +11,7 @@ use Maatwebsite\Excel\Tests\Data\Stubs\FromNonEloquentQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExportWithEagerLoad;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExportWithPrepareRows;
+use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryWithJoinExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersScoutExport;
 use Maatwebsite\Excel\Tests\TestCase;
 
@@ -55,6 +56,23 @@ class FromQueryTest extends TestCase
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
 
         $allUsers = $export->query()->get()->map(function (User $user) {
+            return array_values($user->toArray());
+        })->toArray();
+
+        $this->assertEquals($allUsers, $contents);
+    }
+
+    public function test_can_export_from_query_with_join()
+    {
+        $export = new FromUsersQueryWithJoinExport();
+
+        $response = $export->store('from-query-store.xlsx');
+
+        $this->assertTrue($response);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
+
+        $allUsers = $export->query->get()->map(function (User $user) {
             return array_values($user->toArray());
         })->toArray();
 

--- a/tests/Data/Stubs/FromUsersQueryWithJoinExport.php
+++ b/tests/Data/Stubs/FromUsersQueryWithJoinExport.php
@@ -41,6 +41,6 @@ class FromUsersQueryWithJoinExport implements FromQuery, WithCustomChunkSize
      */
     public function chunkSize(): int
     {
-        return 1000;
+        return 10;
     }
 }

--- a/tests/Data/Stubs/FromUsersQueryWithJoinExport.php
+++ b/tests/Data/Stubs/FromUsersQueryWithJoinExport.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+
+class FromUsersQueryWithJoinExport implements FromQuery, WithCustomChunkSize
+{
+    use Exportable;
+
+    public $query;
+
+    public function __construct()
+    {
+        $this->query = User::query();
+    }
+
+    /**
+     * @return Builder|EloquentBuilder|Relation
+     */
+    public function query()
+    {
+        return $this->query
+            ->join(
+                'group_user',
+                'group_user.user_id',
+                '=',
+                'users.id'
+            )
+            ->select('users.*', 'group_user.group_id as gid');
+    }
+
+    /**
+     * @return int
+     */
+    public function chunkSize(): int
+    {
+        return 1000;
+    }
+}


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

This is a fix for [an issue reported in the Laravel Nova Excel project](https://github.com/SpartnerNL/Laravel-Nova-Excel/issues/181) - though it turned out that the issue was here, not there.

The problem is that if query() makes non-idempotent changes to the $query, it's likely to result in a corrupt query. So to avoid this, we need to make sure we only call query() once, and once we have an instance, take care not to alter it further. I found that calling chunk() on $query altered it, making a test fail. I solved that by cloning it, so the changes caused by chunk can be discarded.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No, just one.

3️⃣  Does it include tests, if possible?

Yes

4️⃣  Any drawbacks? Possible breaking changes?

If there are other places that `query()` is called in a similar way, the same problem may occur there too. I ran into the same thing inside a test.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
