### PR TITLE
fix: Method DefaultValueBinder::bindValue not compatible with PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder::bindValue

### DIFF
--- a/src/DefaultValueBinder.php
+++ b/src/DefaultValueBinder.php
@@ -12,7 +12,7 @@ class DefaultValueBinder extends PhpSpreadsheetDefaultValueBinder
      * @param  mixed  $value  Value to bind in cell
      * @return bool
      */
-    public function bindValue(Cell $cell, $value)
+    public function bindValue(Cell $cell, mixed $value) : bool
     {
         if (is_array($value)) {
             $value = \json_encode($value);


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

- In PHP Version 8.2.18 the method bindValue from DefaultValueBinder must be exactly the PhpOffice\PhpSpreadsheet\Cell::bindValue
![image](https://github.com/user-attachments/assets/0dca7f8e-fdb2-4645-a48a-e624d35bf146)
![image](https://github.com/user-attachments/assets/bc88dd30-25a7-4a86-b04a-fdc4ea681cdf)
- So i fixed it.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
- No, its only one PR.

3️⃣  Does it include tests, if possible?
- Already have it: ExcelTest::test_can_download_an_export_object_with_facade
- Before:
![image](https://github.com/user-attachments/assets/234f41fc-be10-415e-af91-d50e69b3f3fd)
- After:
![image](https://github.com/user-attachments/assets/4ac78667-28bc-4e19-990a-101b11ec8c14)

4️⃣  Any drawbacks? Possible breaking changes?
- No, just added same param types, and return to DefaultValueBinder::bindValue method

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
- You're welcome :)
