### PR TITLE
 DefaultValueBinder::bindValue not compatible

### DIFF
--- a/src/DefaultValueBinder.php
+++ b/src/DefaultValueBinder.php
@@ -12,7 +12,7 @@ class DefaultValueBinder extends PhpSpreadsheetDefaultValueBinder
      * @param  mixed  $value  Value to bind in cell
      * @return bool
      */
-    public function bindValue(Cell $cell, $value)
+    public function bindValue(Cell $cell, mixed $value): bool
     {
         if (is_array($value)) {
             $value = \json_encode($value);


### PR DESCRIPTION
Declaration is not compatible with PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder::bindValue

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣  Does it include tests, if possible?

4️⃣  Any drawbacks? Possible breaking changes?

5️⃣  Mark the following tasks as done:

- [ ] Checked the codebase to ensure that your feature doesn't already exist.
- [ ] Take note of the contributing guidelines.
- [ ] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
