### PR TITLE
Change parameters of NoTypeDetectedException because of php deprecati…

### DIFF
--- a/src/Factories/ReaderFactory.php
+++ b/src/Factories/ReaderFactory.php
@@ -81,7 +81,7 @@ class ReaderFactory
         try {
             return IOFactory::identify($temporaryFile->getLocalPath());
         } catch (Exception $e) {
-            throw new NoTypeDetectedException(null, null, $e);
+            throw new NoTypeDetectedException('', 0, $e);
         }
     }
 }


### PR DESCRIPTION
Hello,

When exception is thrown with parameters as null, PHP deprecation messages are shown. I tried to change parameters to empty string and 0 for code - basically defaults. I think, that this could not break anything, but it would remove these deprecation messages.

1️⃣  Why should it be added? What are the benefits of this change?
No deprecation messages when exception is thrown. Messages are:
```
1) [...]/vendor/maatwebsite/excel/src/Exceptions/NoTypeDetectedException.php:20
Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated
2) [...]/vendor/maatwebsite/excel/src/Exceptions/NoTypeDetectedException.php:20
Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated
```

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣  Does it include tests, if possible?
No.

4️⃣  Any drawbacks? Possible breaking changes?
No.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
