### PR TITLE
refactor: explicit nullable parameters

### DIFF
--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -20,7 +20,7 @@ class MemoryCache implements CacheInterface
     /**
      * @param  int|null  $memoryLimit
      */
-    public function __construct(int $memoryLimit = null)
+    public function __construct(?int $memoryLimit = null)
     {
         $this->memoryLimit = $memoryLimit;
     }

--- a/src/Cache/MemoryCacheDeprecated.php
+++ b/src/Cache/MemoryCacheDeprecated.php
@@ -20,7 +20,7 @@ class MemoryCacheDeprecated implements CacheInterface
     /**
      * @param  int|null  $memoryLimit
      */
-    public function __construct(int $memoryLimit = null)
+    public function __construct(?int $memoryLimit = null)
     {
         $this->memoryLimit = $memoryLimit;
     }

--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -17,7 +17,7 @@ trait Exportable
      *
      * @throws NoFilenameGivenException
      */
-    public function download(string $fileName = null, string $writerType = null, array $headers = null)
+    public function download(?string $fileName = null, ?string $writerType = null, ?array $headers = null)
     {
         $headers    = $headers ?? $this->headers ?? [];
         $fileName   = $fileName ?? $this->fileName ?? null;
@@ -39,7 +39,7 @@ trait Exportable
      *
      * @throws NoFilePathGivenException
      */
-    public function store(string $filePath = null, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function store(?string $filePath = null, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
     {
         $filePath = $filePath ?? $this->filePath ?? null;
 
@@ -65,7 +65,7 @@ trait Exportable
      *
      * @throws NoFilePathGivenException
      */
-    public function queue(string $filePath = null, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function queue(?string $filePath = null, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
     {
         $filePath = $filePath ?? $this->filePath ?? null;
 

--- a/src/Concerns/Importable.php
+++ b/src/Concerns/Importable.php
@@ -28,7 +28,7 @@ trait Importable
      *
      * @throws NoFilePathGivenException
      */
-    public function import($filePath = null, string $disk = null, string $readerType = null)
+    public function import($filePath = null, ?string $disk = null, ?string $readerType = null)
     {
         $filePath = $this->getFilePath($filePath);
 
@@ -48,7 +48,7 @@ trait Importable
      *
      * @throws NoFilePathGivenException
      */
-    public function toArray($filePath = null, string $disk = null, string $readerType = null): array
+    public function toArray($filePath = null, ?string $disk = null, ?string $readerType = null): array
     {
         $filePath = $this->getFilePath($filePath);
 
@@ -68,7 +68,7 @@ trait Importable
      *
      * @throws NoFilePathGivenException
      */
-    public function toCollection($filePath = null, string $disk = null, string $readerType = null): Collection
+    public function toCollection($filePath = null, ?string $disk = null, ?string $readerType = null): Collection
     {
         $filePath = $this->getFilePath($filePath);
 
@@ -89,7 +89,7 @@ trait Importable
      * @throws NoFilePathGivenException
      * @throws InvalidArgumentException
      */
-    public function queue($filePath = null, string $disk = null, string $readerType = null)
+    public function queue($filePath = null, ?string $disk = null, ?string $readerType = null)
     {
         if (!$this instanceof ShouldQueue) {
             throw new InvalidArgumentException('Importable should implement ShouldQueue to be queued.');

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -79,7 +79,7 @@ class Excel implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function download($export, string $fileName, string $writerType = null, array $headers = [])
+    public function download($export, string $fileName, ?string $writerType = null, array $headers = [])
     {
         // Clear output buffer to prevent stuff being prepended to the Excel output.
         if (ob_get_length() > 0) {
@@ -99,7 +99,7 @@ class Excel implements Exporter, Importer
      *
      * @param  string|null  $disk  Fallback for usage with named properties
      */
-    public function store($export, string $filePath, string $diskName = null, string $writerType = null, $diskOptions = [], string $disk = null)
+    public function store($export, string $filePath, ?string $diskName = null, ?string $writerType = null, $diskOptions = [], ?string $disk = null)
     {
         if ($export instanceof ShouldQueue) {
             return $this->queue($export, $filePath, $diskName ?: $disk, $writerType, $diskOptions);
@@ -120,7 +120,7 @@ class Excel implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
     {
         $writerType = FileTypeDetector::detectStrict($filePath, $writerType);
 
@@ -149,7 +149,7 @@ class Excel implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function import($import, $filePath, string $disk = null, string $readerType = null)
+    public function import($import, $filePath, ?string $disk = null, ?string $readerType = null)
     {
         $readerType = FileTypeDetector::detect($filePath, $readerType);
         $response   = $this->reader->read($import, $filePath, $readerType, $disk);
@@ -164,7 +164,7 @@ class Excel implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function toArray($import, $filePath, string $disk = null, string $readerType = null): array
+    public function toArray($import, $filePath, ?string $disk = null, ?string $readerType = null): array
     {
         $readerType = FileTypeDetector::detect($filePath, $readerType);
 
@@ -174,7 +174,7 @@ class Excel implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function toCollection($import, $filePath, string $disk = null, string $readerType = null): Collection
+    public function toCollection($import, $filePath, ?string $disk = null, ?string $readerType = null): Collection
     {
         $readerType = FileTypeDetector::detect($filePath, $readerType);
 
@@ -184,7 +184,7 @@ class Excel implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function queueImport(ShouldQueue $import, $filePath, string $disk = null, string $readerType = null)
+    public function queueImport(ShouldQueue $import, $filePath, ?string $disk = null, ?string $readerType = null)
     {
         return $this->import($import, $filePath, $disk, $readerType);
     }
@@ -197,7 +197,7 @@ class Excel implements Exporter, Importer
      *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
-    protected function export($export, string $fileName, string $writerType = null): TemporaryFile
+    protected function export($export, string $fileName, ?string $writerType = null): TemporaryFile
     {
         $writerType = FileTypeDetector::detectStrict($fileName, $writerType);
 

--- a/src/Exceptions/NoFilePathGivenException.php
+++ b/src/Exceptions/NoFilePathGivenException.php
@@ -15,7 +15,7 @@ class NoFilePathGivenException extends InvalidArgumentException implements Larav
     public function __construct(
         $message = 'A filepath needs to be passed.',
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exceptions/NoFilenameGivenException.php
+++ b/src/Exceptions/NoFilenameGivenException.php
@@ -15,7 +15,7 @@ class NoFilenameGivenException extends InvalidArgumentException implements Larav
     public function __construct(
         $message = 'A filename needs to be passed in order to download the export',
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exceptions/NoTypeDetectedException.php
+++ b/src/Exceptions/NoTypeDetectedException.php
@@ -15,7 +15,7 @@ class NoTypeDetectedException extends Exception implements LaravelExcelException
     public function __construct(
         $message = 'No ReaderType or WriterType could be detected. Make sure you either pass a valid extension to the filename or pass an explicit type.',
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exceptions/UnreadableFileException.php
+++ b/src/Exceptions/UnreadableFileException.php
@@ -15,7 +15,7 @@ class UnreadableFileException extends Exception implements LaravelExcelException
     public function __construct(
         $message = 'File could not be read',
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -14,7 +14,7 @@ interface Exporter
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function download($export, string $fileName, string $writerType = null, array $headers = []);
+    public function download($export, string $fileName, ?string $writerType = null, array $headers = []);
 
     /**
      * @param  object  $export
@@ -27,7 +27,7 @@ interface Exporter
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function store($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = []);
+    public function store($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = []);
 
     /**
      * @param  object  $export
@@ -37,7 +37,7 @@ interface Exporter
      * @param  mixed  $diskOptions
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
-    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = []);
+    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = []);
 
     /**
      * @param  object  $export

--- a/src/Factories/ReaderFactory.php
+++ b/src/Factories/ReaderFactory.php
@@ -27,7 +27,7 @@ class ReaderFactory
      *
      * @throws Exception
      */
-    public static function make($import, TemporaryFile $file, string $readerType = null): IReader
+    public static function make($import, TemporaryFile $file, ?string $readerType = null): IReader
     {
         $reader = IOFactory::createReader(
             $readerType ?: static::identify($file)

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -57,7 +57,7 @@ class ExcelFake implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function download($export, string $fileName, string $writerType = null, array $headers = [])
+    public function download($export, string $fileName, ?string $writerType = null, array $headers = [])
     {
         $this->downloads[$fileName] = $export;
 
@@ -69,7 +69,7 @@ class ExcelFake implements Exporter, Importer
      *
      * @param  string|null  $diskName  Fallback for usage with named properties
      */
-    public function store($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [], string $diskName = null)
+    public function store($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = [], ?string $diskName = null)
     {
         if ($export instanceof ShouldQueue) {
             return $this->queue($export, $filePath, $disk ?: $diskName, $writerType);
@@ -83,7 +83,7 @@ class ExcelFake implements Exporter, Importer
     /**
      * {@inheritdoc}
      */
-    public function queue($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
     {
         Queue::fake();
 
@@ -124,7 +124,7 @@ class ExcelFake implements Exporter, Importer
      * @param  string|null  $readerType
      * @return Reader|PendingDispatch
      */
-    public function import($import, $file, string $disk = null, string $readerType = null)
+    public function import($import, $file, ?string $disk = null, ?string $readerType = null)
     {
         if ($import instanceof ShouldQueue) {
             return $this->queueImport($import, $file, $disk, $readerType);
@@ -144,7 +144,7 @@ class ExcelFake implements Exporter, Importer
      * @param  string|null  $readerType
      * @return array
      */
-    public function toArray($import, $file, string $disk = null, string $readerType = null): array
+    public function toArray($import, $file, ?string $disk = null, ?string $readerType = null): array
     {
         $filePath = ($file instanceof UploadedFile) ? $file->getFilename() : $file;
 
@@ -160,7 +160,7 @@ class ExcelFake implements Exporter, Importer
      * @param  string|null  $readerType
      * @return Collection
      */
-    public function toCollection($import, $file, string $disk = null, string $readerType = null): Collection
+    public function toCollection($import, $file, ?string $disk = null, ?string $readerType = null): Collection
     {
         $filePath = ($file instanceof UploadedFile) ? $file->getFilename() : $file;
 
@@ -176,7 +176,7 @@ class ExcelFake implements Exporter, Importer
      * @param  string  $readerType
      * @return PendingDispatch
      */
-    public function queueImport(ShouldQueue $import, $file, string $disk = null, string $readerType = null)
+    public function queueImport(ShouldQueue $import, $file, ?string $disk = null, ?string $readerType = null)
     {
         Queue::fake();
 

--- a/src/Files/Disk.php
+++ b/src/Files/Disk.php
@@ -32,7 +32,7 @@ class Disk
      * @param  string|null  $name
      * @param  array  $diskOptions
      */
-    public function __construct(IlluminateFilesystem $disk, string $name = null, array $diskOptions = [])
+    public function __construct(IlluminateFilesystem $disk, ?string $name = null, array $diskOptions = [])
     {
         $this->disk        = $disk;
         $this->name        = $name;

--- a/src/Files/Filesystem.php
+++ b/src/Files/Filesystem.php
@@ -24,7 +24,7 @@ class Filesystem
      * @param  array  $diskOptions
      * @return Disk
      */
-    public function disk(string $disk = null, array $diskOptions = []): Disk
+    public function disk(?string $disk = null, array $diskOptions = []): Disk
     {
         return new Disk(
             $this->filesystem->disk($disk),

--- a/src/Files/TemporaryFile.php
+++ b/src/Files/TemporaryFile.php
@@ -50,7 +50,7 @@ abstract class TemporaryFile
      * @param  string|null  $disk
      * @return TemporaryFile
      */
-    public function copyFrom($filePath, string $disk = null): TemporaryFile
+    public function copyFrom($filePath, ?string $disk = null): TemporaryFile
     {
         if ($filePath instanceof UploadedFile) {
             $readStream = fopen($filePath->getRealPath(), 'rb');

--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -20,7 +20,7 @@ class TemporaryFileFactory
      * @param  string|null  $temporaryPath
      * @param  string|null  $temporaryDisk
      */
-    public function __construct(string $temporaryPath = null, string $temporaryDisk = null)
+    public function __construct(?string $temporaryPath = null, ?string $temporaryDisk = null)
     {
         $this->temporaryPath = $temporaryPath;
         $this->temporaryDisk = $temporaryDisk;
@@ -30,7 +30,7 @@ class TemporaryFileFactory
      * @param  string|null  $fileExtension
      * @return TemporaryFile
      */
-    public function make(string $fileExtension = null): TemporaryFile
+    public function make(?string $fileExtension = null): TemporaryFile
     {
         if (null !== $this->temporaryDisk) {
             return $this->makeRemote($fileExtension);
@@ -44,7 +44,7 @@ class TemporaryFileFactory
      * @param  string|null  $fileExtension
      * @return LocalTemporaryFile
      */
-    public function makeLocal(string $fileName = null, string $fileExtension = null): LocalTemporaryFile
+    public function makeLocal(?string $fileName = null, ?string $fileExtension = null): LocalTemporaryFile
     {
         if (!file_exists($this->temporaryPath) && !mkdir($concurrentDirectory = $this->temporaryPath, config('excel.temporary_files.local_permissions.dir', 0777), true) && !is_dir($concurrentDirectory)) {
             throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
@@ -59,7 +59,7 @@ class TemporaryFileFactory
      * @param  string|null  $fileExtension
      * @return RemoteTemporaryFile
      */
-    private function makeRemote(string $fileExtension = null): RemoteTemporaryFile
+    private function makeRemote(?string $fileExtension = null): RemoteTemporaryFile
     {
         $filename = $this->generateFilename($fileExtension);
 
@@ -74,7 +74,7 @@ class TemporaryFileFactory
      * @param  string|null  $fileExtension
      * @return string
      */
-    private function generateFilename(string $fileExtension = null): string
+    private function generateFilename(?string $fileExtension = null): string
     {
         return 'laravel-excel-' . Str::random(32) . ($fileExtension ? '.' . $fileExtension : '');
     }

--- a/src/Helpers/FileTypeDetector.php
+++ b/src/Helpers/FileTypeDetector.php
@@ -14,7 +14,7 @@ class FileTypeDetector
      *
      * @throws NoTypeDetectedException
      */
-    public static function detect($filePath, string $type = null)
+    public static function detect($filePath, ?string $type = null)
     {
         if (null !== $type) {
             return $type;
@@ -41,7 +41,7 @@ class FileTypeDetector
      *
      * @throws NoTypeDetectedException
      */
-    public static function detectStrict(string $filePath, string $type = null): string
+    public static function detectStrict(string $filePath, ?string $type = null): string
     {
         $type = static::detect($filePath, $type);
 

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -14,7 +14,7 @@ interface Importer
      * @param  string|null  $readerType
      * @return Reader|\Illuminate\Foundation\Bus\PendingDispatch
      */
-    public function import($import, $filePath, string $disk = null, string $readerType = null);
+    public function import($import, $filePath, ?string $disk = null, ?string $readerType = null);
 
     /**
      * @param  object  $import
@@ -23,7 +23,7 @@ interface Importer
      * @param  string|null  $readerType
      * @return array
      */
-    public function toArray($import, $filePath, string $disk = null, string $readerType = null): array;
+    public function toArray($import, $filePath, ?string $disk = null, ?string $readerType = null): array;
 
     /**
      * @param  object  $import
@@ -32,7 +32,7 @@ interface Importer
      * @param  string|null  $readerType
      * @return Collection
      */
-    public function toCollection($import, $filePath, string $disk = null, string $readerType = null): Collection;
+    public function toCollection($import, $filePath, ?string $disk = null, ?string $readerType = null): Collection;
 
     /**
      * @param  ShouldQueue  $import
@@ -41,5 +41,5 @@ interface Importer
      * @param  string  $readerType
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
-    public function queueImport(ShouldQueue $import, $filePath, string $disk = null, string $readerType = null);
+    public function queueImport(ShouldQueue $import, $filePath, ?string $disk = null, ?string $readerType = null);
 }

--- a/src/Imports/EndRowFinder.php
+++ b/src/Imports/EndRowFinder.php
@@ -12,7 +12,7 @@ class EndRowFinder
      * @param  int|null  $highestRow
      * @return int|null
      */
-    public static function find($import, int $startRow = null, int $highestRow = null)
+    public static function find($import, ?int $startRow = null, ?int $highestRow = null)
     {
         if (!$import instanceof WithLimit) {
             return null;

--- a/src/Imports/HeadingRowFormatter.php
+++ b/src/Imports/HeadingRowFormatter.php
@@ -50,7 +50,7 @@ class HeadingRowFormatter
     /**
      * @param  string  $name
      */
-    public static function default(string $name = null)
+    public static function default(?string $name = null)
     {
         if (null !== $name && !isset(static::$customFormatters[$name]) && !in_array($name, static::$defaultFormatters, true)) {
             throw new InvalidArgumentException(sprintf('Formatter "%s" does not exist', $name));

--- a/src/Jobs/QueueImport.php
+++ b/src/Jobs/QueueImport.php
@@ -22,7 +22,7 @@ class QueueImport implements ShouldQueue
     /**
      * @param  ShouldQueue  $import
      */
-    public function __construct(ShouldQueue $import = null)
+    public function __construct(?ShouldQueue $import = null)
     {
         if ($import) {
             $this->timeout = $import->timeout ?? null;

--- a/src/Jobs/StoreQueuedExport.php
+++ b/src/Jobs/StoreQueuedExport.php
@@ -36,7 +36,7 @@ class StoreQueuedExport implements ShouldQueue
      * @param  string|null  $disk
      * @param  array|string  $diskOptions
      */
-    public function __construct(TemporaryFile $temporaryFile, string $filePath, string $disk = null, $diskOptions = [])
+    public function __construct(TemporaryFile $temporaryFile, string $filePath, ?string $disk = null, $diskOptions = [])
     {
         $this->disk          = $disk;
         $this->filePath      = $filePath;

--- a/src/Mixins/DownloadCollectionMixin.php
+++ b/src/Mixins/DownloadCollectionMixin.php
@@ -16,7 +16,7 @@ class DownloadCollectionMixin
      */
     public function downloadExcel()
     {
-        return function (string $fileName, string $writerType = null, $withHeadings = false, array $responseHeaders = []) {
+        return function (string $fileName, ?string $writerType = null, $withHeadings = false, array $responseHeaders = []) {
             $export = new class($this, $withHeadings) implements FromCollection, WithHeadings
             {
                 use Exportable;

--- a/src/Mixins/DownloadQueryMacro.php
+++ b/src/Mixins/DownloadQueryMacro.php
@@ -12,7 +12,7 @@ class DownloadQueryMacro
 {
     public function __invoke()
     {
-        return function (string $fileName, string $writerType = null, $withHeadings = false) {
+        return function (string $fileName, ?string $writerType = null, $withHeadings = false) {
             $export = new class($this, $withHeadings) implements FromQuery, WithHeadings
             {
                 use Exportable;

--- a/src/Mixins/ImportAsMacro.php
+++ b/src/Mixins/ImportAsMacro.php
@@ -10,7 +10,7 @@ class ImportAsMacro
 {
     public function __invoke()
     {
-        return function (string $filename, callable $mapping, string $disk = null, string $readerType = null) {
+        return function (string $filename, callable $mapping, ?string $disk = null, ?string $readerType = null) {
             $import = new class(get_class($this->getModel()), $mapping) implements ToModel
             {
                 use Importable;

--- a/src/Mixins/ImportMacro.php
+++ b/src/Mixins/ImportMacro.php
@@ -11,7 +11,7 @@ class ImportMacro
 {
     public function __invoke()
     {
-        return function (string $filename, string $disk = null, string $readerType = null) {
+        return function (string $filename, ?string $disk = null, ?string $readerType = null) {
             $import = new class(get_class($this->getModel())) implements ToModel, WithHeadingRow
             {
                 use Importable;

--- a/src/Mixins/StoreCollectionMixin.php
+++ b/src/Mixins/StoreCollectionMixin.php
@@ -14,7 +14,7 @@ class StoreCollectionMixin
      */
     public function storeExcel()
     {
-        return function (string $filePath, string $disk = null, string $writerType = null, $withHeadings = false) {
+        return function (string $filePath, ?string $disk = null, ?string $writerType = null, $withHeadings = false) {
             $export = new class($this, $withHeadings) implements FromCollection, WithHeadings
             {
                 use Exportable;

--- a/src/Mixins/StoreQueryMacro.php
+++ b/src/Mixins/StoreQueryMacro.php
@@ -12,7 +12,7 @@ class StoreQueryMacro
 {
     public function __invoke()
     {
-        return function (string $filePath, string $disk = null, string $writerType = null, $withHeadings = false) {
+        return function (string $filePath, ?string $disk = null, ?string $writerType = null, $withHeadings = false) {
             $export = new class($this, $withHeadings) implements FromQuery, WithHeadings
             {
                 use Exportable;

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -58,7 +58,7 @@ class QueuedWriter
      * @param  array|string  $diskOptions
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
-    public function store($export, string $filePath, string $disk = null, string $writerType = null, $diskOptions = [])
+    public function store($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
     {
         $extension     = pathinfo($filePath, PATHINFO_EXTENSION);
         $temporaryFile = $this->temporaryFileFactory->make($extension);

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -97,7 +97,7 @@ class Reader
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      * @throws Exception
      */
-    public function read($import, $filePath, string $readerType = null, string $disk = null)
+    public function read($import, $filePath, ?string $readerType = null, ?string $disk = null)
     {
         $this->reader = $this->getReader($import, $filePath, $readerType, $disk);
 
@@ -151,7 +151,7 @@ class Reader
      * @throws NoTypeDetectedException
      * @throws Exceptions\SheetNotFoundException
      */
-    public function toArray($import, $filePath, string $readerType = null, string $disk = null): array
+    public function toArray($import, $filePath, ?string $readerType = null, ?string $disk = null): array
     {
         $this->reader = $this->getReader($import, $filePath, $readerType, $disk);
 
@@ -195,7 +195,7 @@ class Reader
      * @throws NoTypeDetectedException
      * @throws Exceptions\SheetNotFoundException
      */
-    public function toCollection($import, $filePath, string $readerType = null, string $disk = null): Collection
+    public function toCollection($import, $filePath, ?string $readerType = null, ?string $disk = null): Collection
     {
         $this->reader = $this->getReader($import, $filePath, $readerType, $disk);
         $this->loadSpreadsheet($import);
@@ -419,7 +419,7 @@ class Reader
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      * @throws InvalidArgumentException
      */
-    private function getReader($import, $filePath, string $readerType = null, string $disk = null): IReader
+    private function getReader($import, $filePath, ?string $readerType = null, ?string $disk = null): IReader
     {
         $shouldQueue = $import instanceof ShouldQueue;
         if ($shouldQueue && !$import instanceof WithChunkReading) {

--- a/src/Row.php
+++ b/src/Row.php
@@ -169,7 +169,7 @@ class Row implements ArrayAccess
      *
      * @internal
      */
-    public function setPreparationCallback(Closure $preparationCallback = null)
+    public function setPreparationCallback(?Closure $preparationCallback = null)
     {
         $this->preparationCallback = $preparationCallback;
     }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -325,7 +325,7 @@ class Sheet
      * @param  bool  $formatData
      * @return array
      */
-    public function toArray($import, int $startRow = null, $nullValue = null, $calculateFormulas = false, $formatData = false)
+    public function toArray($import, ?int $startRow = null, $nullValue = null, $calculateFormulas = false, $formatData = false)
     {
         if ($startRow > $this->worksheet->getHighestRow()) {
             return [];
@@ -376,7 +376,7 @@ class Sheet
      * @param  bool  $formatData
      * @return Collection
      */
-    public function toCollection($import, int $startRow = null, $nullValue = null, $calculateFormulas = false, $formatData = false): Collection
+    public function toCollection($import, ?int $startRow = null, $nullValue = null, $calculateFormulas = false, $formatData = false): Collection
     {
         $rows = $this->toArray($import, $startRow, $nullValue, $calculateFormulas, $formatData);
 
@@ -544,7 +544,7 @@ class Sheet
      * @param  string|null  $startCell
      * @param  bool  $strictNullComparison
      */
-    public function append(array $rows, string $startCell = null, bool $strictNullComparison = false)
+    public function append(array $rows, ?string $startCell = null, bool $strictNullComparison = false)
     {
         if (!$startCell) {
             $startCell = 'A1';

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -203,7 +203,7 @@ class Writer
      *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
-    public function addNewSheet(int $sheetIndex = null)
+    public function addNewSheet(?int $sheetIndex = null)
     {
         return new Sheet($this->spreadsheet->createSheet($sheetIndex));
     }


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

This PR makes Laravel-Excel compatible with PHP 8.4 without throwing deprecation warnings while maintaining backwards compatibility. There is a similar PR (#4248), but that one is also incorporating some breaking changes.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣  Does it include tests, if possible?

Tests are already running for 8.4.

4️⃣  Any drawbacks? Possible breaking changes?

No.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
