### PR TITLE
fix fromCollection to pass collection instead of array

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -505,7 +505,7 @@ class Sheet
      */
     public function fromCollection(FromCollection $sheetExport)
     {
-        $this->appendRows($sheetExport->collection()->all(), $sheetExport);
+        $this->appendRows(new Collection($sheetExport->collection()->all()), $sheetExport);
     }
 
     /**

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -3,6 +3,8 @@
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Foundation\Bus\PendingDispatch;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use Maatwebsite\Excel\Tests\Data\Stubs\EloquentCollectionWithPrepareRowsExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\EloquentLazyCollectionExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\EloquentLazyCollectionQueuedExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
@@ -96,5 +98,26 @@ class FromCollectionTest extends TestCase
             )->toArray(),
             $contents
         );
+    }
+
+    public function test_can_export_from_collection_with_prepare_rows()
+    {
+        $export = new EloquentCollectionWithPrepareRowsExport;
+
+        $this->assertTrue(method_exists($export, 'prepareRows'));
+
+        $response = $export->store('from-collection-store.xlsx');
+
+        $this->assertTrue($response);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-collection-store.xlsx', 'Xlsx');
+
+        $allUsers = $export->collection()->map(function (User $user) {
+            $user->name .= '_prepared_name';
+
+            return array_values($user->toArray());
+        })->toArray();
+
+        $this->assertEquals($allUsers, $contents);
     }
 }

--- a/tests/Data/Stubs/EloquentCollectionWithPrepareRowsExport.php
+++ b/tests/Data/Stubs/EloquentCollectionWithPrepareRowsExport.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Database\Eloquent\Collection;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+
+class EloquentCollectionWithPrepareRowsExport implements FromCollection
+{
+    use Exportable;
+
+    /**
+     * @return Collection
+     */
+    public function collection()
+    {
+        return new Collection([
+            new User([
+                'firstname' => 'Patrick',
+                'lastname'  => 'Brouwers',
+            ]),
+        ]);
+    }
+
+    /**
+     * @param  iterable  $rows
+     * @return iterable
+     */
+    public function prepareRows($rows)
+    {
+        return $rows->transform(function ($user) {
+            $user->name .= '_prepared_name';
+
+            return $user;
+        })->toArray();
+    }
+}


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
This fixes the issue [#4270](https://github.com/SpartnerNL/Laravel-Excel/issues/4270), which occurred because `collection()->all()` does not return a collection. This change ensures it returns a collection.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣  Does it include tests, if possible?
Yes
4️⃣  Any drawbacks? Possible breaking changes?
No
5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
