### PR TITLE
Include end row in `LimitFilter`

### DIFF
--- a/src/Filters/LimitFilter.php
+++ b/src/Filters/LimitFilter.php
@@ -34,6 +34,6 @@ class LimitFilter implements IReadFilter
      */
     public function readCell($column, $row, $worksheetName = '')
     {
-        return $row >= $this->startRow && $row < $this->endRow;
+        return $row >= $this->startRow && $row <= $this->endRow;
     }
 }

--- a/tests/Concerns/WithLimitTest.php
+++ b/tests/Concerns/WithLimitTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
 use Maatwebsite\Excel\Concerns\WithLimit;
 use Maatwebsite\Excel\Concerns\WithStartRow;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
@@ -102,6 +103,72 @@ class WithLimitTest extends TestCase
         };
 
         $import->import('import-users.xlsx');
+    }
+
+    public function test_can_import_single_with_heading_row()
+    {
+        $import = new class implements ToArray, WithLimit, WithHeadingRow
+        {
+            use Importable;
+
+            /**
+             * @param  array  $array
+             */
+            public function array(array $array)
+            {
+                Assert::assertEquals([
+                    [
+                        'name' => 'Patrick Brouwers',
+                        'email' => 'patrick@maatwebsite.nl',
+                    ],
+                ], $array);
+            }
+
+            /**
+             * @return int
+             */
+            public function limit(): int
+            {
+                return 1;
+            }
+        };
+
+        $import->import('import-users-with-headings.xlsx');
+    }
+
+    public function test_can_import_multiple_with_heading_row()
+    {
+        $import = new class implements ToArray, WithLimit, WithHeadingRow
+        {
+            use Importable;
+
+            /**
+             * @param  array  $array
+             */
+            public function array(array $array)
+            {
+                Assert::assertEquals([
+                    [
+                        'name' => 'Patrick Brouwers',
+                        'email' => 'patrick@maatwebsite.nl',
+                    ],
+                    [
+                        'name' => 'Taylor Otwell',
+                        'email' => 'taylor@laravel.com',
+                    ],
+                ], $array);
+            }
+
+            /**
+             * @return int
+             */
+            public function limit(): int
+            {
+                return 2;
+            }
+        };
+
+        $import->import('import-users-with-headings.xlsx');
     }
 
     public function test_can_set_limit_bigger_than_row_size()

--- a/tests/Concerns/WithLimitTest.php
+++ b/tests/Concerns/WithLimitTest.php
@@ -118,7 +118,7 @@ class WithLimitTest extends TestCase
             {
                 Assert::assertEquals([
                     [
-                        'name' => 'Patrick Brouwers',
+                        'name'  => 'Patrick Brouwers',
                         'email' => 'patrick@maatwebsite.nl',
                     ],
                 ], $array);
@@ -149,11 +149,11 @@ class WithLimitTest extends TestCase
             {
                 Assert::assertEquals([
                     [
-                        'name' => 'Patrick Brouwers',
+                        'name'  => 'Patrick Brouwers',
                         'email' => 'patrick@maatwebsite.nl',
                     ],
                     [
-                        'name' => 'Taylor Otwell',
+                        'name'  => 'Taylor Otwell',
                         'email' => 'taylor@laravel.com',
                     ],
                 ], $array);


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

This is a fixup for #4217. That PR fixed the original issue by including the end row, but at the same time excluded the heading row, which caused #4271.

This PR modifies `LimitFilter` to include both the heading row and the end row, as suggested [here](https://github.com/SpartnerNL/Laravel-Excel/issues/3439#issuecomment-968948515). The tests were also updated to ensure the headings are imported correctly.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣  Does it include tests, if possible?

Yes.

4️⃣  Any drawbacks? Possible breaking changes?

Same drawbacks as #4217.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
