### PR TITLE
fix: preserve RemoteTemporaryFile type when working with remote storage

### DIFF
--- a/src/Files/RemoteTemporaryFile.php
+++ b/src/Files/RemoteTemporaryFile.php
@@ -93,14 +93,14 @@ class RemoteTemporaryFile extends TemporaryFile
     /**
      * @return TemporaryFile
      */
-    public function sync(): TemporaryFile
+    public function sync(bool $copy = true): TemporaryFile
     {
         if (!$this->localTemporaryFile->exists()) {
             $this->localTemporaryFile = resolve(TemporaryFileFactory::class)
                 ->makeLocal(Arr::last(explode('/', $this->filename)));
         }
 
-        $this->disk()->copy(
+        $copy && $this->disk()->copy(
             $this,
             $this->localTemporaryFile->getLocalPath()
         );

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel;
 
-use Illuminate\Support\Arr;
 use Maatwebsite\Excel\Concerns\WithBackgroundColor;
 use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 use Maatwebsite\Excel\Concerns\WithDefaultStyles;

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -177,8 +177,9 @@ class Writer
         );
 
         if ($temporaryFile instanceof RemoteTemporaryFile && !$temporaryFile->existsLocally() && !$this->isRunningServerless()) {
-            $temporaryFile = resolve(TemporaryFileFactory::class)
-                ->makeLocal(Arr::last(explode('/', $temporaryFile->getLocalPath())));
+            // just ensure that local copy exists (it creates the directory structure),
+            // no need to copy remote content since it will be overwritten below
+            $temporaryFile->sync(false);
         }
 
         $writer->save(


### PR DESCRIPTION
### 1️⃣ Why should it be added? What are the benefits of this change?

This PR fixes a critical bug in distributed environments where Laravel Excel exports are queued but processed across multiple servers. When using a remote disk for temporary files, if a different server processes the initial export job than the one that received the request, the export fails.

The issue occurs because the current code flow replaces the [`RemoteTemporaryFile`](https://github.com/SpartnerNL/Laravel-Excel/blob/3.1/src/Files/RemoteTemporaryFile.php) instance with a new [`LocalTemporaryFile`](https://github.com/SpartnerNL/Laravel-Excel/blob/3.1/src/Files/LocalTemporaryFile.php) when trying to ensure the local file exists [^1]. This type change breaks the subsequent operations that expect a `RemoteTemporaryFile` and the remote file is never updated [^2]. This results in an empty file being loaded when the next job in the chain tries to process it.

The fix preserves the `RemoteTemporaryFile` type while ensuring the local directory structure exists for writing, making queued exports work reliably in distributed environments.

### 2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, this PR contains a single focused fix for the `RemoteTemporaryFile` handling issue.

### 3️⃣ Does it include tests, if possible?

No, as this is specifically related to multi-server distributed environments which would be challenging to simulate in automated tests.

### 4️⃣ Any drawbacks? Possible breaking changes?

No breaking changes. The modification to `RemoteTemporaryFile::sync()` adds an optional parameter with a default value that preserves the original behavior.

### 5️⃣ Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- ~[ ] Added tests to ensure against regression.~ _(not applicable in this case)_

### 6️⃣ Thanks for contributing! 🙌

--------

### Additional Information

**Problem Details:**
In a distributed environment with multiple servers (A and B), when using a remote disk for temporary files:

1. **Server A** handles the initial request from a controller that queues the Excel export through [`Exportable::queue()`](https://github.com/SpartnerNL/Laravel-Excel/blob/3.1/src/Concerns/Exportable.php#L68-L83)
    - A `LocalTemporaryFile` instance is created [^3] _(`RemoteTemporaryFile` if a temporalDisk is specified [^4])_.
    - `LocalTemporaryFile` touches the file on the local disk [^5].
    - `RemoteTemporaryFile` touches the file on the remote server [^6].
2. The export jobs are queued in a chain [^7] (`QueueExport` → `AppendQueryToSheet`|`AppendDataToSheet`|... → `CloseSheet` → `StoreQueuedExport`).
3. If **Server B** picks up the `QueueExport` job, it detects that the local file doesn't exist [^1].
4. In the original version, it created a new `LocalTemporaryFile` instance, changing the type from `RemoteTemporaryFile` to `LocalTemporaryFile`.
5. When saving the Excel file, the remote file was never updated because the condition `instanceof RemoteTemporaryFile` [^2] failed.
6. Subsequent jobs failed because when they load the temporary file, they load an empty file from the remote location _(since it was never updated)_.

The fix preserves the `RemoteTemporaryFile` type by modifying [`RemoteTemporaryFile::sync()`](https://github.com/SpartnerNL/Laravel-Excel/blob/3.1/src/Files/RemoteTemporaryFile.php#L96-L109) to accept an optional parameter that allows creating the directory structure without copying content _(which would be redundant since it's about to be overwritten anyway)_ [^2].

---

[^1]: https://github.com/SpartnerNL/Laravel-Excel/blob/e25d44a2d91da9179cd2d7fec952313548597a79/src/Writer.php#L179-L182
[^2]: https://github.com/SpartnerNL/Laravel-Excel/blob/e25d44a2d91da9179cd2d7fec952313548597a79/src/Writer.php#L188-L191
[^3]: https://github.com/SpartnerNL/Laravel-Excel/blob/e25d44a2d91da9179cd2d7fec952313548597a79/src/QueuedWriter.php#L64
[^4]: https://github.com/SpartnerNL/Laravel-Excel/blob/e25d44a2d91da9179cd2d7fec952313548597a79/src/Files/TemporaryFileFactory.php#L35-L37
[^5]: https://github.com/SpartnerNL/Laravel-Excel/blob/e25d44a2d91da9179cd2d7fec952313548597a79/src/Files/LocalTemporaryFile.php#L17
[^6]: https://github.com/SpartnerNL/Laravel-Excel/blob/e25d44a2d91da9179cd2d7fec952313548597a79/src/Files/RemoteTemporaryFile.php#L40
[^7]: https://github.com/SpartnerNL/Laravel-Excel/blob/e25d44a2d91da9179cd2d7fec952313548597a79/src/QueuedWriter.php#L76