### PR TITLE
Fixed StdObject conversion for null values in Sheet map arrayable row

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -699,10 +699,10 @@ class Sheet
 
         // Convert StdObjects to arrays
         if (is_object($row)) {
-            return json_decode(json_encode($row), true);
+            $row = json_decode(json_encode($row), true);
         }
 
-        return $row;
+        return $row ?? [];
     }
 
     /**


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

Fixes an issue I ran into with the `mapArrayableRow()` method with null values since the method signature has an array return type a null value breaks this and it crashes. I believe it is a good change to apply for all to fix the problem.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣  Does it include tests, if possible?

I have not just yet. I will try to see about this.

4️⃣  Any drawbacks? Possible breaking changes?

I do not believe so.

5️⃣  Mark the following tasks as done:

- [X] Checked the codebase to ensure that your feature doesn't already exist.
- [X] Take note of the contributing guidelines.
- [X] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
