### PR TITLE
Support `SkipsOnError` with `OnEachRow`

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -299,11 +299,13 @@ class Sheet
                         try {
                             app(RowValidator::class)->validate($toValidate, $import);
                             $import->onRow($sheetRow);
-                        } catch (RowSkippedException) {
+                        } catch (RowSkippedException $e) {
                         } catch (Throwable $e) {
-                            $import instanceof SkipsOnError
-                                ? $import->onError($e)
-                                : throw $e;
+                            if ($import instanceof SkipsOnError) {
+                                $import->onError($e);
+                            } else {
+                                throw $e;
+                            }
                         }
                     } else {
                         $import->onRow($sheetRow);

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -15,6 +15,7 @@ use Maatwebsite\Excel\Concerns\FromView;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
+use Maatwebsite\Excel\Concerns\SkipsOnError;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -58,6 +59,7 @@ use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\BaseDrawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use Throwable;
 
 /** @mixin Worksheet */
 class Sheet
@@ -297,7 +299,11 @@ class Sheet
                         try {
                             app(RowValidator::class)->validate($toValidate, $import);
                             $import->onRow($sheetRow);
-                        } catch (RowSkippedException $e) {
+                        } catch (RowSkippedException) {
+                        } catch (Throwable $e) {
+                            $import instanceof SkipsOnError
+                                ? $import->onError($e)
+                                : throw $e;
                         }
                     } else {
                         $import->onRow($sheetRow);

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -311,11 +311,11 @@ class Sheet
                         try {
                             $import->onRow($sheetRow);
                         } catch (Throwable $e) {
-                           if ($import instanceof SkipsOnError) {
-                               $import->onError($e);
-                           } else {
-                               throw $e;
-                           }
+                            if ($import instanceof SkipsOnError) {
+                                $import->onError($e);
+                            } else {
+                                throw $e;
+                            }
                         }
                     }
                 }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -308,7 +308,15 @@ class Sheet
                             }
                         }
                     } else {
-                        $import->onRow($sheetRow);
+                        try {
+                            $import->onRow($sheetRow);
+                        } catch (Throwable $e) {
+                           if ($import instanceof SkipsOnError) {
+                               $import->onError($e);
+                           } else {
+                               throw $e;
+                           }
+                        }
                     }
                 }
 

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -240,4 +240,114 @@ class SkipsOnErrorTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
     }
+
+    public function test_can_skip_on_error_when_exception_thrown_in_onrow()
+    {
+        $import = new class implements OnEachRow, SkipsOnError
+        {
+            use Importable;
+
+            public $errors = 0;
+            public $processedRows = 0;
+
+            /**
+             * @param  Row  $row
+             */
+            public function onRow(Row $row)
+            {
+                $this->processedRows++;
+
+                $rowArray = $row->toArray();
+
+                // Throw an exception for the second row (Taylor Otwell)
+                if ($rowArray[1] === 'taylor@laravel.com') {
+                    throw new \Exception('Custom error in onRow for Taylor');
+                }
+
+                User::create([
+                    'name'     => $rowArray[0],
+                    'email'    => $rowArray[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @param  Throwable  $e
+             */
+            public function onError(Throwable $e)
+            {
+                Assert::assertInstanceOf(\Exception::class, $e);
+                Assert::assertEquals('Custom error in onRow for Taylor', $e->getMessage());
+
+                $this->errors++;
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertEquals(1, $import->errors);
+        $this->assertEquals(2, $import->processedRows); // Both rows should be processed, but one throws exception
+
+        // Should have inserted the valid row
+        $this->assertDatabaseHas('users', [
+            'email' => 'patrick@maatwebsite.nl',
+        ]);
+
+        // Should have skipped inserting the row that threw exception
+        $this->assertDatabaseMissing('users', [
+            'email' => 'taylor@laravel.com',
+        ]);
+    }
+
+    public function test_can_skip_errors_and_collect_all_errors_when_exception_thrown_in_onrow()
+    {
+        $import = new class implements OnEachRow, SkipsOnError
+        {
+            use Importable, SkipsErrors;
+
+            public $processedRows = 0;
+
+            /**
+             * @param  Row  $row
+             */
+            public function onRow(Row $row)
+            {
+                $this->processedRows++;
+
+                $rowArray = $row->toArray();
+
+                // Throw an exception for the second row (Taylor Otwell)
+                if ($rowArray[1] === 'taylor@laravel.com') {
+                    throw new \RuntimeException('Runtime error in onRow for Taylor');
+                }
+
+                User::create([
+                    'name'     => $rowArray[0],
+                    'email'    => $rowArray[1],
+                    'password' => 'secret',
+                ]);
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(1, $import->errors());
+        $this->assertEquals(2, $import->processedRows); // Both rows should be processed, but one throws exception
+
+        /** @var Throwable $e */
+        $e = $import->errors()->first();
+
+        $this->assertInstanceOf(\RuntimeException::class, $e);
+        $this->assertEquals('Runtime error in onRow for Taylor', $e->getMessage());
+
+        // Should have inserted the valid row
+        $this->assertDatabaseHas('users', [
+            'email' => 'patrick@maatwebsite.nl',
+        ]);
+
+        // Should have skipped inserting the row that threw exception
+        $this->assertDatabaseMissing('users', [
+            'email' => 'taylor@laravel.com',
+        ]);
+    }
 }

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -4,12 +4,17 @@ namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
+use Illuminate\Validation\Rule;
 use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\SkipsErrors;
 use Maatwebsite\Excel\Concerns\SkipsOnError;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithValidation;
+use Maatwebsite\Excel\Row;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\TestCase;
+use Maatwebsite\Excel\Validators\ValidationException;
 use PHPUnit\Framework\Assert;
 use Throwable;
 
@@ -109,6 +114,128 @@ class SkipsOnErrorTest extends TestCase
         ]);
 
         // Should have skipped inserting
+        $this->assertDatabaseMissing('users', [
+            'email' => 'taylor@laravel.com',
+        ]);
+    }
+
+    public function test_can_skip_on_error_when_using_oneachrow_with_validation()
+    {
+        $import = new class implements OnEachRow, WithValidation, SkipsOnError
+        {
+            use Importable;
+
+            public $errors = 0;
+            public $processedRows = 0;
+
+            /**
+             * @param  Row  $row
+             */
+            public function onRow(Row $row)
+            {
+                $this->processedRows++;
+
+                // This will be called for valid rows
+                $rowArray = $row->toArray();
+
+                User::create([
+                    'name'     => $rowArray[0],
+                    'email'    => $rowArray[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @return array
+             */
+            public function rules(): array
+            {
+                return [
+                    '1' => Rule::in(['patrick@maatwebsite.nl']),
+                ];
+            }
+
+            /**
+             * @param  Throwable  $e
+             */
+            public function onError(Throwable $e)
+            {
+                Assert::assertInstanceOf(ValidationException::class, $e);
+                Assert::stringContains($e->getMessage(), 'The selected 1 is invalid');
+
+                $this->errors++;
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertEquals(1, $import->errors);
+        $this->assertEquals(1, $import->processedRows); // Only the valid row should be processed
+
+        // Should have inserted the valid row
+        $this->assertDatabaseHas('users', [
+            'email' => 'patrick@maatwebsite.nl',
+        ]);
+
+        // Should have skipped inserting the invalid row
+        $this->assertDatabaseMissing('users', [
+            'email' => 'taylor@laravel.com',
+        ]);
+    }
+
+    public function test_can_skip_errors_and_collect_all_errors_when_using_oneachrow_with_validation()
+    {
+        $import = new class implements OnEachRow, WithValidation, SkipsOnError
+        {
+            use Importable, SkipsErrors;
+
+            public $processedRows = 0;
+
+            /**
+             * @param  Row  $row
+             */
+            public function onRow(Row $row)
+            {
+                $this->processedRows++;
+
+                // This will be called for valid rows
+                $rowArray = $row->toArray();
+
+                User::create([
+                    'name'     => $rowArray[0],
+                    'email'    => $rowArray[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            /**
+             * @return array
+             */
+            public function rules(): array
+            {
+                return [
+                    '1' => Rule::in(['patrick@maatwebsite.nl']),
+                ];
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(1, $import->errors());
+        $this->assertEquals(1, $import->processedRows); // Only the valid row should be processed
+
+        /** @var Throwable $e */
+        $e = $import->errors()->first();
+
+        $this->assertInstanceOf(ValidationException::class, $e);
+        $this->stringContains($e->getMessage(), 'The selected 1 is invalid');
+
+        // Should have inserted the valid row
+        $this->assertDatabaseHas('users', [
+            'email' => 'patrick@maatwebsite.nl',
+        ]);
+
+        // Should have skipped inserting the invalid row
         $this->assertDatabaseMissing('users', [
             'email' => 'taylor@laravel.com',
         ]);

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -125,7 +125,7 @@ class SkipsOnErrorTest extends TestCase
         {
             use Importable;
 
-            public $errors = 0;
+            public $errors        = 0;
             public $processedRows = 0;
 
             /**

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -247,7 +247,7 @@ class SkipsOnErrorTest extends TestCase
         {
             use Importable;
 
-            public $errors = 0;
+            public $errors        = 0;
             public $processedRows = 0;
 
             /**


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
This adds support for using the `SkipsOnError` interface when using the `OnEachRow` interface, allowing users to not have to catch exceptions themselves in `OnEachRow` and utilize a dedicated handle method.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣  Does it include tests, if possible?
Yes.

4️⃣  Any drawbacks? Possible breaking changes?
No.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
