### PR TITLE
Adds new GroupedUser relation with mandatory relation to groups + tests

### DIFF
--- a/tests/Concerns/ToModelTest.php
+++ b/tests/Concerns/ToModelTest.php
@@ -10,7 +10,6 @@ use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\PersistRelations;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
-use Maatwebsite\Excel\Tests\Data\Stubs\Database\GroupedUser;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\TestCase;
 
@@ -31,18 +30,19 @@ class ToModelTest extends TestCase
     {
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel {
+        $import = new class implements ToModel
+        {
             use Importable;
 
             /**
-             * @param array $row
+             * @param  array  $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 return new User([
-                    'name' => $row[0],
-                    'email' => $row[1],
+                    'name'     => $row[0],
+                    'email'    => $row[1],
                     'password' => 'secret',
                 ]);
             }
@@ -54,30 +54,31 @@ class ToModelTest extends TestCase
         DB::connection()->disableQueryLog();
 
         $this->assertDatabaseHas('users', [
-            'name' => 'Patrick Brouwers',
+            'name'  => 'Patrick Brouwers',
             'email' => 'patrick@maatwebsite.nl',
         ]);
 
         $this->assertDatabaseHas('users', [
-            'name' => 'Taylor Otwell',
+            'name'  => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
         ]);
     }
 
     public function test_has_timestamps_when_imported_single_model()
     {
-        $import = new class implements ToModel {
+        $import = new class implements ToModel
+        {
             use Importable;
 
             /**
-             * @param array $row
+             * @param  array  $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 return new User([
-                    'name' => $row[0],
-                    'email' => $row[1],
+                    'name'     => $row[0],
+                    'email'    => $row[1],
                     'password' => 'secret',
                 ]);
             }
@@ -95,26 +96,27 @@ class ToModelTest extends TestCase
     {
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel {
+        $import = new class implements ToModel
+        {
             use Importable;
 
             /**
-             * @param array $row
+             * @param  array  $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 $user1 = new User([
-                    'name' => $row[0],
-                    'email' => $row[1],
+                    'name'     => $row[0],
+                    'email'    => $row[1],
                     'password' => 'secret',
                 ]);
 
                 $faker = Factory::create();
 
                 $user2 = new User([
-                    'name' => $faker->name,
-                    'email' => $faker->email,
+                    'name'     => $faker->name,
+                    'email'    => $faker->email,
                     'password' => 'secret',
                 ]);
 
@@ -132,18 +134,19 @@ class ToModelTest extends TestCase
     {
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel {
+        $import = new class implements ToModel
+        {
             use Importable;
 
             /**
-             * @param array $row
+             * @param  array  $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 $user = new User([
-                    'name' => $row[0],
-                    'email' => $row[1],
+                    'name'     => $row[0],
+                    'email'    => $row[1],
                     'password' => 'secret',
                 ]);
 
@@ -170,18 +173,19 @@ class ToModelTest extends TestCase
 
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel, PersistRelations {
+        $import = new class implements ToModel, PersistRelations
+        {
             use Importable;
 
             /**
-             * @param array $row
+             * @param  array  $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 $user = new User([
-                    'name' => $row[0],
-                    'email' => $row[1],
+                    'name'     => $row[0],
+                    'email'    => $row[1],
                     'password' => 'secret',
                 ]);
 
@@ -217,18 +221,19 @@ class ToModelTest extends TestCase
 
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel, PersistRelations {
+        $import = new class implements ToModel, PersistRelations
+        {
             use Importable;
 
             /**
-             * @param array $row
+             * @param  array  $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 $user = new User([
-                    'name' => $row[0],
-                    'email' => $row[1],
+                    'name'     => $row[0],
+                    'email'    => $row[1],
                     'password' => 'secret',
                 ]);
 
@@ -263,18 +268,19 @@ class ToModelTest extends TestCase
 
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel, PersistRelations {
+        $import = new class implements ToModel, PersistRelations
+        {
             use Importable;
 
             /**
-             * @param array $row
+             * @param  array  $row
              * @return GroupedUser
              */
             public function model(array $row): GroupedUser
             {
                 $groupedUser = new GroupedUser([
-                    'name' => $row[0],
-                    'email' => $row[1],
+                    'name'     => $row[0],
+                    'email'    => $row[1],
                     'password' => 'secret',
                 ]);
 

--- a/tests/Concerns/ToModelTest.php
+++ b/tests/Concerns/ToModelTest.php
@@ -11,6 +11,7 @@ use Maatwebsite\Excel\Concerns\PersistRelations;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\GroupedUser;
 use Maatwebsite\Excel\Tests\TestCase;
 
 class ToModelTest extends TestCase

--- a/tests/Concerns/ToModelTest.php
+++ b/tests/Concerns/ToModelTest.php
@@ -10,8 +10,8 @@ use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\PersistRelations;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
-use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\GroupedUser;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\TestCase;
 
 class ToModelTest extends TestCase

--- a/tests/Concerns/ToModelTest.php
+++ b/tests/Concerns/ToModelTest.php
@@ -10,6 +10,7 @@ use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\PersistRelations;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\GroupedUser;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\TestCase;
 
@@ -30,19 +31,18 @@ class ToModelTest extends TestCase
     {
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel
-        {
+        $import = new class implements ToModel {
             use Importable;
 
             /**
-             * @param  array  $row
+             * @param array $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 return new User([
-                    'name'     => $row[0],
-                    'email'    => $row[1],
+                    'name' => $row[0],
+                    'email' => $row[1],
                     'password' => 'secret',
                 ]);
             }
@@ -54,31 +54,30 @@ class ToModelTest extends TestCase
         DB::connection()->disableQueryLog();
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Patrick Brouwers',
+            'name' => 'Patrick Brouwers',
             'email' => 'patrick@maatwebsite.nl',
         ]);
 
         $this->assertDatabaseHas('users', [
-            'name'  => 'Taylor Otwell',
+            'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
         ]);
     }
 
     public function test_has_timestamps_when_imported_single_model()
     {
-        $import = new class implements ToModel
-        {
+        $import = new class implements ToModel {
             use Importable;
 
             /**
-             * @param  array  $row
+             * @param array $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 return new User([
-                    'name'     => $row[0],
-                    'email'    => $row[1],
+                    'name' => $row[0],
+                    'email' => $row[1],
                     'password' => 'secret',
                 ]);
             }
@@ -96,27 +95,26 @@ class ToModelTest extends TestCase
     {
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel
-        {
+        $import = new class implements ToModel {
             use Importable;
 
             /**
-             * @param  array  $row
+             * @param array $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 $user1 = new User([
-                    'name'     => $row[0],
-                    'email'    => $row[1],
+                    'name' => $row[0],
+                    'email' => $row[1],
                     'password' => 'secret',
                 ]);
 
                 $faker = Factory::create();
 
                 $user2 = new User([
-                    'name'     => $faker->name,
-                    'email'    => $faker->email,
+                    'name' => $faker->name,
+                    'email' => $faker->email,
                     'password' => 'secret',
                 ]);
 
@@ -134,19 +132,18 @@ class ToModelTest extends TestCase
     {
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel
-        {
+        $import = new class implements ToModel {
             use Importable;
 
             /**
-             * @param  array  $row
+             * @param array $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 $user = new User([
-                    'name'     => $row[0],
-                    'email'    => $row[1],
+                    'name' => $row[0],
+                    'email' => $row[1],
                     'password' => 'secret',
                 ]);
 
@@ -173,19 +170,18 @@ class ToModelTest extends TestCase
 
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel, PersistRelations
-        {
+        $import = new class implements ToModel, PersistRelations {
             use Importable;
 
             /**
-             * @param  array  $row
+             * @param array $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 $user = new User([
-                    'name'     => $row[0],
-                    'email'    => $row[1],
+                    'name' => $row[0],
+                    'email' => $row[1],
                     'password' => 'secret',
                 ]);
 
@@ -221,19 +217,18 @@ class ToModelTest extends TestCase
 
         DB::connection()->enableQueryLog();
 
-        $import = new class implements ToModel, PersistRelations
-        {
+        $import = new class implements ToModel, PersistRelations {
             use Importable;
 
             /**
-             * @param  array  $row
+             * @param array $row
              * @return Model|Model[]|null
              */
             public function model(array $row)
             {
                 $user = new User([
-                    'name'     => $row[0],
-                    'email'    => $row[1],
+                    'name' => $row[0],
+                    'email' => $row[1],
                     'password' => 'secret',
                 ]);
 
@@ -254,6 +249,48 @@ class ToModelTest extends TestCase
         $users = User::all();
         $users->each(function (User $user) {
             $this->assertInstanceOf(Group::class, $user->groups->first());
+        });
+
+        $this->assertCount(2, $users);
+        $this->assertEquals(2, Group::count());
+        DB::connection()->disableQueryLog();
+    }
+
+    public function test_can_import_models_with_non_nullable_belongs_to_many_relations()
+    {
+        Group::query()->truncate();
+        GroupedUser::query()->truncate();
+
+        DB::connection()->enableQueryLog();
+
+        $import = new class implements ToModel, PersistRelations {
+            use Importable;
+
+            /**
+             * @param array $row
+             * @return GroupedUser
+             */
+            public function model(array $row): GroupedUser
+            {
+                $groupedUser = new GroupedUser([
+                    'name' => $row[0],
+                    'email' => $row[1],
+                    'password' => 'secret',
+                ]);
+
+                $groupedUser->setRelation('group', new Group(['name' => $row[0]]));
+
+                return $groupedUser;
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertCount(6, DB::getQueryLog());
+
+        $users = GroupedUser::all();
+        $users->each(function (GroupedUser $groupedUser) {
+            $this->assertInstanceOf(Group::class, $groupedUser->group);
         });
 
         $this->assertCount(2, $users);

--- a/tests/Data/Stubs/Database/GroupedUser.php
+++ b/tests/Data/Stubs/Database/GroupedUser.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GroupedUser extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+}

--- a/tests/Data/Stubs/Database/Migrations/0000_00_00_000003_create_grouped_users_table.php
+++ b/tests/Data/Stubs/Database/Migrations/0000_00_00_000003_create_grouped_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateGroupedUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('grouped_users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+            $table->string('password');
+            $table->unsignedInteger('group_id')->index();
+
+            $table->datetimes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('grouped_users');
+    }
+}

--- a/tests/Data/Stubs/Database/Migrations/0000_00_00_000003_create_grouped_users_table.php
+++ b/tests/Data/Stubs/Database/Migrations/0000_00_00_000003_create_grouped_users_table.php
@@ -18,7 +18,7 @@ class CreateGroupedUsersTable extends Migration
             $table->string('password');
             $table->unsignedInteger('group_id')->index();
 
-            $table->datetimes();
+            $table->timestamps();
         });
     }
 


### PR DESCRIPTION
This PR shows the tests that fails when a relation is **not** nullable using `PersistRelations`.

Context for this PR is showing a test would fail if it'd exist. Context for this can be found in: #4277 

This is not necessarily intended to be merged as it doesn't include a fix for the issue (yet(?)).
