### PR TITLE
fix: missing InteractsWithQueue trait in QueueExport class

### DIFF
--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -4,6 +4,7 @@ namespace Maatwebsite\Excel\Jobs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Exceptions\NoSheetsFoundException;
 use Maatwebsite\Excel\Files\TemporaryFile;
@@ -13,7 +14,7 @@ use Throwable;
 
 class QueueExport implements ShouldQueue
 {
-    use ExtendedQueueable, Dispatchable;
+    use ExtendedQueueable, Dispatchable, InteractsWithQueue;
 
     /**
      * @var object

--- a/tests/InteractsWithQueueTest.php
+++ b/tests/InteractsWithQueueTest.php
@@ -6,6 +6,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Maatwebsite\Excel\Jobs\AppendDataToSheet;
 use Maatwebsite\Excel\Jobs\AppendQueryToSheet;
 use Maatwebsite\Excel\Jobs\AppendViewToSheet;
+use Maatwebsite\Excel\Jobs\QueueExport;
 use Maatwebsite\Excel\Jobs\ReadChunk;
 
 class InteractsWithQueueTest extends TestCase
@@ -36,5 +37,10 @@ class InteractsWithQueueTest extends TestCase
     public function test_append_view_to_sheet_job_can_interact_with_queue()
     {
         $this->assertContains(InteractsWithQueue::class, class_uses(AppendViewToSheet::class));
+    }
+
+    public function test_queue_export_job_can_interact_with_queue()
+    {
+        $this->assertContains(InteractsWithQueue::class, class_uses(QueueExport::class));
     }
 }


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

In the documentation, it's mentioned that we can add a RateLimited middleware to an export job (https://docs.laravel-excel.com/3.1/exports/queued.html#queued). However, the QueueExport class is missing the InteractsWithQueue trait, so it cannot release the job back to the queue (see the below error):

```
Call to undefined method Maatwebsite\Excel\Jobs\QueueExport::release() {"exception":"[object] (Error(code: 0): Call to undefined method Maatwebsite\\Excel\\Jobs\\QueueExport::release() at /Users/leon/Herd/tc-portal/vendor/laravel/framework/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php:53)
``` 

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

no

3️⃣  Does it include tests, if possible?

yes

4️⃣  Any drawbacks? Possible breaking changes?

no

5️⃣  Mark the following tasks as done:

- [ x] Checked the codebase to ensure that your feature doesn't already exist.
- [ x] Take note of the contributing guidelines.
- [x ] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
