### PR TITLE
Fix: correct Laravel version range from 11.x to 12.x in compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ Versions will be supported for a limited amount of time.
 |---- |----|----|----|
 | 2.1 | <=5.6 | <=7.0 | Unsupported since 15-5-2018 |
 | 3.0 | ^5.5 |  ^7.0 | Unsupported since 31-12-2018 |
-| 3.1 | >=5.8 \| <=11.x |  ^7.2 \| ^8.0 | New features |
+| 3.1 | >=5.8 \| <=12.x |  ^7.2 \| ^8.0 | New features |


### PR DESCRIPTION
1️⃣ Why should it be added? What are the benefits of this change?
This PR corrects a small documentation inaccuracy in the version compatibility table.
Currently, the table lists “<=11.x” for Laravel support under version 3.1, but the package is also compatible with Laravel 12.x.
Updating it improves clarity and prevents confusion for users installing the package on newer Laravel versions.

2️⃣ Does it contain multiple, unrelated changes?
No — this PR only contains a single, isolated documentation fix in the version compatibility table.

3️⃣ Does it include tests, if possible?
Not applicable — this change affects documentation only.

4️⃣ Any drawbacks? Possible breaking changes?
No — it does not alter code, APIs, or behavior. Documentation-only change.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
