### PR TITLE
Add PHP 8.5 to test matrix in CI workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
         laravel: [12, 11, 10, 9, 8, 7, 6, 5.8]
         dependency-version: [prefer-stable]
         os: [ubuntu-latest]
@@ -60,6 +60,8 @@ jobs:
           - laravel: 12
             php: 7.4
           - laravel: 11
+            php: 8.5
+          - laravel: 11
             php: 8.1
           - laravel: 11
             php: 8.0
@@ -71,12 +73,18 @@ jobs:
             php: 7.4
           - laravel: 10
             php: 8.4
+          - laravel: 10
+            php: 8.5
           - laravel: 9
             php: 7.4
           - laravel: 9
             php: 8.4
+          - laravel: 9
+            php: 8.5
           - laravel: 8
             php: 8.4
+          - laravel: 8
+            php: 8.5
           - laravel: 7
             php: 8.0
           - laravel: 7
@@ -87,6 +95,8 @@ jobs:
             php: 8.3
           - laravel: 7
             php: 8.4
+          - laravel: 7
+            php: 8.5
           - laravel: 6
             php: 8.0
           - laravel: 6
@@ -97,6 +107,8 @@ jobs:
             php: 8.3
           - laravel: 6
             php: 8.4
+          - laravel: 6
+            php: 8.5
           - laravel: 5.8
             php: 8.0
           - laravel: 5.8
@@ -107,6 +119,8 @@ jobs:
             php: 8.3
           - laravel: 5.8
             php: 8.4
+          - laravel: 5.8
+            php: 8.5
 
     name: PHP${{ matrix.php }} - L${{ matrix.laravel }}
 


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

Run the test suite against PHP 8.5 (for Laravel 12)

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣  Does it include tests, if possible?

NA

4️⃣  Any drawbacks? Possible breaking changes?

No

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.

6️⃣  Thanks for contributing! 🙌
