### PR TITLE
Fix 8.5 deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ Versions will be supported for a limited amount of time.
 |---- |----|----|----|
 | 2.1 | <=5.6 | <=7.0 | Unsupported since 15-5-2018 |
 | 3.0 | ^5.5 |  ^7.0 | Unsupported since 31-12-2018 |
-| 3.1 | >=5.8 \| <=11.x |  ^7.2 \| ^8.0 | New features |
+| 3.1 | >=5.8 \| <=12.x |  ^7.2 \| ^8.0 | New features |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ exports and imports.
       <img src="https://poser.pugx.org/maatwebsite/excel/downloads.png" alt="Total Downloads">
   </a>
 
-  <a href="https://packagist.org/packages/maatwebsite/excel">
+  <a href="https://github.com/SpartnerNL/Laravel-Excel/blob/3.1/LICENSE">
     <img src="https://poser.pugx.org/maatwebsite/excel/license.png" alt="License">
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ exports and imports.
 
 <p align="center">
   <a href="https://github.com/SpartnerNL/Laravel-Excel/actions">
-    <img src="https://github.com/Maatwebsite/Laravel-Excel/workflows/Run%20tests/badge.svg?branch=3.1" alt="Github Actions">
+    <img src="https://github.com/SpartnerNL/Laravel-Excel/actions/workflows/run-tests.yml/badge.svg" alt="Github Actions">
   </a>
 
   <a href="https://styleci.io/repos/14259390">

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ exports and imports.
 
 <p align="center">
   <a href="https://github.com/SpartnerNL/Laravel-Excel/actions">
-    <img src="https://github.com/SpartnerNL/Laravel-Excel/actions/workflows/run-tests.yml/badge.svg" alt="Github Actions">
+    <img src="https://github.com/Maatwebsite/Laravel-Excel/workflows/Run%20tests/badge.svg?branch=3.1" alt="Github Actions">
   </a>
 
   <a href="https://styleci.io/repos/14259390">
@@ -47,7 +47,7 @@ exports and imports.
       <img src="https://poser.pugx.org/maatwebsite/excel/downloads.png" alt="Total Downloads">
   </a>
 
-  <a href="https://github.com/SpartnerNL/Laravel-Excel/blob/3.1/LICENSE">
+  <a href="https://packagist.org/packages/maatwebsite/excel">
     <img src="https://poser.pugx.org/maatwebsite/excel/license.png" alt="License">
   </a>
 </p>
@@ -102,4 +102,4 @@ Versions will be supported for a limited amount of time.
 |---- |----|----|----|
 | 2.1 | <=5.6 | <=7.0 | Unsupported since 15-5-2018 |
 | 3.0 | ^5.5 |  ^7.0 | Unsupported since 31-12-2018 |
-| 3.1 | >=5.8 \| <=12.x |  ^7.2 \| ^8.0 | New features |
+| 3.1 | >=5.8 \| <=11.x |  ^7.2 \| ^8.0 | New features |

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -766,6 +766,8 @@ class Sheet
      */
     protected function buildColumnRange(string $lower, string $upper)
     {
+        $increment = function_exists('str_increment') ? function($cell) { return str_increment($cell); } : function($cell) { return ++$cell; };
+
         $upper = str_increment($upper);
         for ($i = $lower; $i !== $upper; $i = str_increment($i)) {
             yield $i;

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -766,6 +766,9 @@ class Sheet
      */
     protected function buildColumnRange(string $lower, string $upper)
     {
+	/**
+         * @callable(string): string $increment
+         */
 	$increment = function_exists('str_increment') ? function($cell) { 
 	    return str_increment($cell); 
 	} : function($cell) { 

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -775,8 +775,8 @@ class Sheet
 	    return ++$cell; 
 	};
 
-        $upper = str_increment($upper);
-        for ($i = $lower; $i !== $upper; $i = str_increment($i)) {
+        $upper = $increment($upper);
+        for ($i = $lower; $i !== $upper; $i = $increment($i)) {
             yield $i;
         }
     }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -766,7 +766,11 @@ class Sheet
      */
     protected function buildColumnRange(string $lower, string $upper)
     {
-        $increment = function_exists('str_increment') ? function($cell) { return str_increment($cell); } : function($cell) { return ++$cell; };
+	$increment = function_exists('str_increment') ? function($cell) { 
+	    return str_increment($cell); 
+	} : function($cell) { 
+	    return ++$cell; 
+	};
 
         $upper = str_increment($upper);
         for ($i = $lower; $i !== $upper; $i = str_increment($i)) {

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -766,8 +766,8 @@ class Sheet
      */
     protected function buildColumnRange(string $lower, string $upper)
     {
-        $upper++;
-        for ($i = $lower; $i !== $upper; $i++) {
+        $upper = str_increment($upper);
+        for ($i = $lower; $i !== $upper; $i = str_increment($i)) {
             yield $i;
         }
     }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -769,10 +769,10 @@ class Sheet
         /**
          * @callable(string): string $increment
          */
-        $increment = function_exists('str_increment') ? function($cell) { 
-         return str_increment($cell); 
-        } : function($cell) { 
-         return ++$cell; 
+        $increment = function_exists('str_increment') ? function ($cell) {
+            return str_increment($cell);
+        } : function ($cell) {
+            return ++$cell;
         };
 
         $upper = $increment($upper);

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -766,14 +766,14 @@ class Sheet
      */
     protected function buildColumnRange(string $lower, string $upper)
     {
-	/**
+        /**
          * @callable(string): string $increment
          */
-	$increment = function_exists('str_increment') ? function($cell) { 
-	    return str_increment($cell); 
-	} : function($cell) { 
-	    return ++$cell; 
-	};
+        $increment = function_exists('str_increment') ? function($cell) { 
+         return str_increment($cell); 
+        } : function($cell) { 
+         return ++$cell; 
+        };
 
         $upper = $increment($upper);
         for ($i = $lower; $i !== $upper; $i = $increment($i)) {


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

Fixes a PHP 8.5 deprecation warning

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣  Does it include tests, if possible?

Is already covered

4️⃣  Any drawbacks? Possible breaking changes?

Doesn't support PHP < 8.3

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
