### PR TITLE
Remove incompatible simple-cache version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php": "^7.0||^8.0",
     "phpoffice/phpspreadsheet": "^1.30.0",
     "illuminate/support": "5.8.*||^6.0||^7.0||^8.0||^9.0||^10.0||^11.0||^12.0",
-    "psr/simple-cache": "^1.0||^2.0||^3.0",
+    "psr/simple-cache": "^1.0||^2.0",
     "composer/semver": "^3.3"
   },
   "require-dev": {


### PR DESCRIPTION
phpoffice/phpspreadsheet ^1.30.0 is not compatible with psr/simple-cache v3.x

A fatal error is triggered when instantiating the `SimpleCache1` class:

<code>PHP Fatal error:  Declaration of PhpOffice\PhpSpreadsheet\Collection\Memory\SimpleCache1::get($key, $default = null) must be compatible with Psr\SimpleCache\CacheInterface::get(string $key, mixed $default = null): mixed in /Users/morten/Code/hubhus/vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Collection/Memory/SimpleCache1.php on line 63</code>