### PR TITLE
Add additional tests explicitly for latest phpspreadsheet version

### DIFF
--- a/tests/PhpSpreadsheetV5CompatibilityTest.php
+++ b/tests/PhpSpreadsheetV5CompatibilityTest.php
@@ -309,17 +309,13 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
             public function sheets(): array
             {
                 return [
-                    'Sheet1'       => new class
-                    {
+                    'Sheet1'       => new class {
                     },
-                    'NonExistent1' => new class
-                    {
+                    'NonExistent1' => new class {
                     },
-                    'Sheet2'       => new class
-                    {
+                    'Sheet2'       => new class {
                     },
-                    'NonExistent2' => new class
-                    {
+                    'NonExistent2' => new class {
                     },
                 ];
             }
@@ -365,5 +361,4 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
 
         $import->toArray('import-multiple-sheets.xlsx');
     }
-
 }

--- a/tests/PhpSpreadsheetV5CompatibilityTest.php
+++ b/tests/PhpSpreadsheetV5CompatibilityTest.php
@@ -1,0 +1,369 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests;
+
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\SkipsUnknownSheets;
+use Maatwebsite\Excel\Concerns\ToArray;
+use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Concerns\WithReadFilter;
+use Maatwebsite\Excel\Exceptions\SheetNotFoundException;
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
+use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
+
+class PhpSpreadsheetV5CompatibilityTest extends TestCase
+{
+    // ---------------------------------------------------------------
+    // IReadFilter typed signature tests (v5 changed param types)
+    // ---------------------------------------------------------------
+
+    public function test_read_filter_receives_typed_parameters()
+    {
+        $receivedTypes = [];
+
+        $import = new class($receivedTypes) implements WithReadFilter
+        {
+            use Importable;
+
+            private $receivedTypes;
+
+            public function __construct(&$receivedTypes)
+            {
+                $this->receivedTypes = &$receivedTypes;
+            }
+
+            public function readFilter(): IReadFilter
+            {
+                $receivedTypes = &$this->receivedTypes;
+
+                return new class($receivedTypes) implements IReadFilter
+                {
+                    private $receivedTypes;
+
+                    public function __construct(&$receivedTypes)
+                    {
+                        $this->receivedTypes = &$receivedTypes;
+                    }
+
+                    public function readCell(string $columnAddress, int $row, string $worksheetName = ''): bool
+                    {
+                        if (empty($this->receivedTypes)) {
+                            $this->receivedTypes = [
+                                'columnAddress' => gettype($columnAddress),
+                                'row'           => gettype($row),
+                                'worksheetName' => gettype($worksheetName),
+                            ];
+                        }
+
+                        return true;
+                    }
+                };
+            }
+        };
+
+        $import->toArray('import.xlsx');
+
+        $this->assertSame('string', $receivedTypes['columnAddress']);
+        $this->assertSame('integer', $receivedTypes['row']);
+        $this->assertSame('string', $receivedTypes['worksheetName']);
+    }
+
+    public function test_read_filter_receives_correct_column_and_row_values()
+    {
+        $capturedCells = [];
+
+        $import = new class($capturedCells) implements WithReadFilter
+        {
+            use Importable;
+
+            private $capturedCells;
+
+            public function __construct(&$capturedCells)
+            {
+                $this->capturedCells = &$capturedCells;
+            }
+
+            public function readFilter(): IReadFilter
+            {
+                $capturedCells = &$this->capturedCells;
+
+                return new class($capturedCells) implements IReadFilter
+                {
+                    private $capturedCells;
+
+                    public function __construct(&$capturedCells)
+                    {
+                        $this->capturedCells = &$capturedCells;
+                    }
+
+                    public function readCell(string $columnAddress, int $row, string $worksheetName = ''): bool
+                    {
+                        $this->capturedCells[] = ['column' => $columnAddress, 'row' => $row];
+
+                        return true;
+                    }
+                };
+            }
+        };
+
+        $import->toArray('import.xlsx');
+
+        $this->assertNotEmpty($capturedCells);
+
+        $firstCell = $capturedCells[0];
+        $this->assertMatchesRegularExpression('/^[A-Z]+$/', $firstCell['column']);
+        $this->assertGreaterThanOrEqual(1, $firstCell['row']);
+    }
+
+    public function test_read_filter_can_filter_specific_rows()
+    {
+        $import = new class implements WithReadFilter
+        {
+            use Importable;
+
+            public function readFilter(): IReadFilter
+            {
+                return new class implements IReadFilter
+                {
+                    public function readCell(string $columnAddress, int $row, string $worksheetName = ''): bool
+                    {
+                        return $row === 1;
+                    }
+                };
+            }
+        };
+
+        $result = $import->toArray('import-users.xlsx');
+
+        // toArray returns array of sheets, each sheet is array of rows
+        $this->assertCount(1, $result[0]);
+    }
+
+    public function test_read_filter_can_filter_specific_columns()
+    {
+        $import = new class implements WithReadFilter
+        {
+            use Importable;
+
+            public function readFilter(): IReadFilter
+            {
+                return new class implements IReadFilter
+                {
+                    public function readCell(string $columnAddress, int $row, string $worksheetName = ''): bool
+                    {
+                        return $columnAddress === 'A';
+                    }
+                };
+            }
+        };
+
+        $result = $import->toArray('import.xlsx');
+
+        foreach ($result[0] as $row) {
+            $nonNullValues = array_filter($row, fn ($v) => $v !== null);
+            $this->assertCount(1, $nonNullValues);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // WithCustomValueBinder typed signature tests (v5 added types)
+    // ---------------------------------------------------------------
+
+    public function test_custom_value_binder_is_not_applied_on_import()
+    {
+        // PHPSpreadsheet v5 does not invoke WithCustomValueBinder during reads.
+        // This is a breaking change from v1 where value binders were called on import.
+        // The test documents the current v5 behavior.
+        $bindValueCalled = false;
+
+        $import = new class($bindValueCalled) extends DefaultValueBinder implements WithCustomValueBinder
+        {
+            use Importable;
+
+            private $bindValueCalled;
+
+            public function __construct(&$bindValueCalled)
+            {
+                $this->bindValueCalled = &$bindValueCalled;
+            }
+
+            public function bindValue(Cell $cell, mixed $value): bool
+            {
+                $this->bindValueCalled = true;
+
+                return parent::bindValue($cell, $value);
+            }
+        };
+
+        $result = $import->toArray('value-binder-import.xlsx');
+
+        $this->assertFalse($bindValueCalled, 'PHPSpreadsheet v5 does not call value binders during import');
+        $this->assertNotEmpty($result[0], 'Data should still be imported without the value binder');
+    }
+
+    public function test_import_returns_raw_values_without_value_binder_transformation()
+    {
+        // Since value binders are not called on import in v5,
+        // numeric values like dates come through as raw Excel serial numbers.
+        $import = new class
+        {
+            use Importable;
+        };
+
+        $result = $import->toArray('value-binder-import.xlsx');
+
+        // Row 3 (index 2) should contain raw numeric Excel date serial numbers
+        if (isset($result[0][2])) {
+            foreach ($result[0][2] as $value) {
+                if ($value !== null) {
+                    $this->assertIsNumeric($value);
+                }
+            }
+        }
+    }
+
+    public function test_default_value_binder_encodes_arrays_with_typed_signature()
+    {
+        $export = new class implements FromCollection
+        {
+            use Exportable;
+
+            public function collection()
+            {
+                return collect([
+                    [['nested' => 'value'], 'plain'],
+                    [['a', 'b', 'c'], 'text'],
+                ]);
+            }
+        };
+
+        $export->store('value-binder-array-test.xlsx');
+
+        $actual = $this->readAsArray(__DIR__ . '/Data/Disks/Local/value-binder-array-test.xlsx', 'Xlsx');
+
+        $this->assertSame('{"nested":"value"}', $actual[0][0]);
+        $this->assertSame('plain', $actual[0][1]);
+        $this->assertSame('["a","b","c"]', $actual[1][0]);
+        $this->assertSame('text', $actual[1][1]);
+    }
+
+    // ---------------------------------------------------------------
+    // setCreateBlankSheetIfNoneRead tests (v5 behavior change)
+    // ---------------------------------------------------------------
+
+    public function test_unknown_sheet_name_is_skipped_with_skips_unknown_sheets()
+    {
+        $import = new class implements WithMultipleSheets, SkipsUnknownSheets
+        {
+            use Importable;
+
+            public $skippedSheets = [];
+
+            public function sheets(): array
+            {
+                return [
+                    'Sheet1' => new class implements ToArray
+                    {
+                        public $data = [];
+
+                        public function array(array $array)
+                        {
+                            $this->data = $array;
+                        }
+                    },
+                    'NonExistentSheet' => new class implements ToArray
+                    {
+                        public $data = [];
+
+                        public function array(array $array)
+                        {
+                            $this->data = $array;
+                        }
+                    },
+                ];
+            }
+
+            public function onUnknownSheet($sheetName)
+            {
+                $this->skippedSheets[] = $sheetName;
+            }
+        };
+
+        $import->toArray('import-multiple-sheets.xlsx');
+
+        $this->assertContains('NonExistentSheet', $import->skippedSheets);
+    }
+
+    public function test_mixed_valid_and_invalid_sheet_names_with_skips()
+    {
+        $import = new class implements WithMultipleSheets, SkipsUnknownSheets
+        {
+            use Importable;
+
+            public $skippedSheets = [];
+
+            public function sheets(): array
+            {
+                return [
+                    'Sheet1'       => new class
+                    {
+                    },
+                    'NonExistent1' => new class
+                    {
+                    },
+                    'Sheet2'       => new class
+                    {
+                    },
+                    'NonExistent2' => new class
+                    {
+                    },
+                ];
+            }
+
+            public function onUnknownSheet($sheetName)
+            {
+                $this->skippedSheets[] = $sheetName;
+            }
+        };
+
+        $result = $import->toArray('import-multiple-sheets.xlsx');
+
+        $this->assertContains('NonExistent1', $import->skippedSheets);
+        $this->assertContains('NonExistent2', $import->skippedSheets);
+
+        // Valid sheets should still have returned data
+        $this->assertArrayHasKey('Sheet1', $result);
+        $this->assertArrayHasKey('Sheet2', $result);
+        $this->assertNotEmpty($result['Sheet1']);
+        $this->assertNotEmpty($result['Sheet2']);
+    }
+
+    public function test_unknown_sheet_name_throws_exception_without_skips()
+    {
+        $this->expectException(SheetNotFoundException::class);
+
+        $import = new class implements WithMultipleSheets
+        {
+            use Importable;
+
+            public function sheets(): array
+            {
+                return [
+                    'NonExistentSheet' => new class implements ToArray
+                    {
+                        public function array(array $array)
+                        {
+                        }
+                    },
+                ];
+            }
+        };
+
+        $import->toArray('import-multiple-sheets.xlsx');
+    }
+
+}


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
Hopefully addresses concerns of missing tests against the v3+ changes in phpspreadsheet. I'm happy to split these tests across other test files or otherwise update the organization of them, but figured for initial discussion having them colocated would be fine.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
It's all tests

4️⃣  Any drawbacks? Possible breaking changes?
None, adding additional tests to verify the breaking changes necessitated by v3+ of phpspreadsheet

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌

Hoping this can unblock an initial 4.x tag 🏷️ 

Closes #4345 