### PR TITLE
Resolve PHP 8.5 deprecations and add phpspreadsheet 2.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "ext-json": "*",
     "php": "^7.0||^8.0",
-    "phpoffice/phpspreadsheet": "^1.30.0",
+    "phpoffice/phpspreadsheet": "^1.30.0 || ^2.0",
     "illuminate/support": "5.8.*||^6.0||^7.0||^8.0||^9.0||^10.0||^11.0||^12.0||^13.0",
     "psr/simple-cache": "^1.0||^2.0||^3.0",
     "composer/semver": "^3.3"

--- a/src/DefaultValueBinder.php
+++ b/src/DefaultValueBinder.php
@@ -4,20 +4,46 @@ namespace Maatwebsite\Excel;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder as PhpSpreadsheetDefaultValueBinder;
+use PhpOffice\PhpSpreadsheet\Cell\IValueBinder;
 
-class DefaultValueBinder extends PhpSpreadsheetDefaultValueBinder
-{
-    /**
-     * @param  Cell  $cell  Cell to bind value to
-     * @param  mixed  $value  Value to bind in cell
-     * @return bool
-     */
-    public function bindValue(Cell $cell, $value)
+/**
+ * phpspreadsheet 2.0 added a native `: bool` return type to IValueBinder::bindValue().
+ * Two class definitions are needed to satisfy both interface versions without
+ * forcing a breaking signature change on downstream subclasses.
+ *
+ * @see https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/2.0.0
+ */
+if ((new \ReflectionMethod(IValueBinder::class, 'bindValue'))->hasReturnType()) {
+    class DefaultValueBinder extends PhpSpreadsheetDefaultValueBinder
     {
-        if (is_array($value)) {
-            $value = \json_encode($value);
-        }
+        /**
+         * @param  Cell  $cell  Cell to bind value to
+         * @param  mixed  $value  Value to bind in cell
+         */
+        public function bindValue(Cell $cell, $value): bool
+        {
+            if (is_array($value)) {
+                $value = \json_encode($value);
+            }
 
-        return parent::bindValue($cell, $value);
+            return parent::bindValue($cell, $value);
+        }
+    }
+} else {
+    class DefaultValueBinder extends PhpSpreadsheetDefaultValueBinder
+    {
+        /**
+         * @param  Cell  $cell  Cell to bind value to
+         * @param  mixed  $value  Value to bind in cell
+         * @return bool
+         */
+        public function bindValue(Cell $cell, $value)
+        {
+            if (is_array($value)) {
+                $value = \json_encode($value);
+            }
+
+            return parent::bindValue($cell, $value);
+        }
     }
 }

--- a/src/Filters/ChunkReadFilter.php
+++ b/src/Filters/ChunkReadFilter.php
@@ -4,7 +4,14 @@ namespace Maatwebsite\Excel\Filters;
 
 use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 
-class ChunkReadFilter implements IReadFilter
+/**
+ * phpspreadsheet 2.0 added a native `: bool` return type to IReadFilter::readCell().
+ * Two class definitions are needed to satisfy both interface versions without
+ * forcing a breaking signature change on downstream subclasses.
+ *
+ * @see https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/2.0.0
+ */
+trait ChunkReadFilterBase
 {
     /**
      * @var int
@@ -39,17 +46,41 @@ class ChunkReadFilter implements IReadFilter
         $this->endRow        = $startRow + $chunkSize;
         $this->worksheetName = $worksheetName;
     }
+}
 
-    /**
-     * @param  string  $column
-     * @param  int  $row
-     * @param  string  $worksheetName
-     * @return bool
-     */
-    public function readCell($column, $row, $worksheetName = '')
+if ((new \ReflectionMethod(IReadFilter::class, 'readCell'))->hasReturnType()) {
+    class ChunkReadFilter implements IReadFilter
     {
-        //  Only read the heading row, and the rows that are configured in $this->_startRow and $this->_endRow
-        return ($worksheetName === $this->worksheetName || $worksheetName === '')
-            && ($row === $this->headingRow || ($row >= $this->startRow && $row < $this->endRow));
+        use ChunkReadFilterBase;
+
+        /**
+         * @param  string  $column
+         * @param  int  $row
+         * @param  string  $worksheetName
+         */
+        public function readCell($column, $row, $worksheetName = ''): bool
+        {
+            //  Only read the heading row, and the rows that are configured in $this->_startRow and $this->_endRow
+            return ($worksheetName === $this->worksheetName || $worksheetName === '')
+                && ($row === $this->headingRow || ($row >= $this->startRow && $row < $this->endRow));
+        }
+    }
+} else {
+    class ChunkReadFilter implements IReadFilter
+    {
+        use ChunkReadFilterBase;
+
+        /**
+         * @param  string  $column
+         * @param  int  $row
+         * @param  string  $worksheetName
+         * @return bool
+         */
+        public function readCell($column, $row, $worksheetName = '')
+        {
+            //  Only read the heading row, and the rows that are configured in $this->_startRow and $this->_endRow
+            return ($worksheetName === $this->worksheetName || $worksheetName === '')
+                && ($row === $this->headingRow || ($row >= $this->startRow && $row < $this->endRow));
+        }
     }
 }

--- a/src/Filters/LimitFilter.php
+++ b/src/Filters/LimitFilter.php
@@ -4,7 +4,14 @@ namespace Maatwebsite\Excel\Filters;
 
 use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 
-class LimitFilter implements IReadFilter
+/**
+ * phpspreadsheet 2.0 added a native `: bool` return type to IReadFilter::readCell().
+ * Two class definitions are needed to satisfy both interface versions without
+ * forcing a breaking signature change on downstream subclasses.
+ *
+ * @see https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/2.0.0
+ */
+trait LimitFilterBase
 {
     /**
      * @var int
@@ -25,15 +32,37 @@ class LimitFilter implements IReadFilter
         $this->startRow = $startRow;
         $this->endRow   = $startRow + $limit;
     }
+}
 
-    /**
-     * @param  string  $column
-     * @param  int  $row
-     * @param  string  $worksheetName
-     * @return bool
-     */
-    public function readCell($column, $row, $worksheetName = '')
+if ((new \ReflectionMethod(IReadFilter::class, 'readCell'))->hasReturnType()) {
+    class LimitFilter implements IReadFilter
     {
-        return $row >= $this->startRow && $row <= $this->endRow;
+        use LimitFilterBase;
+
+        /**
+         * @param  string  $column
+         * @param  int  $row
+         * @param  string  $worksheetName
+         */
+        public function readCell($column, $row, $worksheetName = ''): bool
+        {
+            return $row >= $this->startRow && $row <= $this->endRow;
+        }
+    }
+} else {
+    class LimitFilter implements IReadFilter
+    {
+        use LimitFilterBase;
+
+        /**
+         * @param  string  $column
+         * @param  int  $row
+         * @param  string  $worksheetName
+         * @return bool
+         */
+        public function readCell($column, $row, $worksheetName = '')
+        {
+            return $row >= $this->startRow && $row <= $this->endRow;
+        }
     }
 }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -766,8 +766,17 @@ class Sheet
      */
     protected function buildColumnRange(string $lower, string $upper)
     {
-        $upper++;
-        for ($i = $lower; $i !== $upper; $i++) {
+        /**
+         * @callable(string): string $increment
+         */
+        $increment = function_exists('str_increment') ? function ($cell) {
+            return str_increment($cell);
+        } : function ($cell) {
+            return ++$cell;
+        };
+
+        $upper = $increment($upper);
+        for ($i = $lower; $i !== $upper; $i = $increment($i)) {
             yield $i;
         }
     }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -767,7 +767,7 @@ class Sheet
     protected function buildColumnRange(string $lower, string $upper)
     {
         /**
-         * @callable(string): string $increment
+         * @var callable(string): string $increment
          */
         $increment = function_exists('str_increment') ? function ($cell) {
             return str_increment($cell);

--- a/tests/Concerns/WithColumnFormattingTest.php
+++ b/tests/Concerns/WithColumnFormattingTest.php
@@ -65,7 +65,7 @@ class WithColumnFormattingTest extends TestCase
 
         $actual = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/with-column-formatting-store.xlsx', 'Xlsx');
 
-        $legacyPhpSpreadsheet = !InstalledVersions::satisfies(new VersionParser, 'phpoffice/phpspreadsheet', '^1.28');
+        $legacyPhpSpreadsheet = !InstalledVersions::satisfies(new VersionParser, 'phpoffice/phpspreadsheet', '^1.28 || ^2.0');
 
         $expected = [
             ['06/03/2018', null],

--- a/tests/Validators/RowValidatorTest.php
+++ b/tests/Validators/RowValidatorTest.php
@@ -89,7 +89,9 @@ class RowValidatorTest extends TestCase
     public function callPrivateMethod(string $name, array $args)
     {
         $method = new \ReflectionMethod(RowValidator::class, $name);
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         return $method->invokeArgs($this->validator, $args);
     }


### PR DESCRIPTION
Closes #4345

1️⃣  Why should it be added? What are the benefits of this change?

phpspreadsheet 1.30.2 requires `php <8.5.0`, blocking installation on PHP 8.5. The `4.x` branch depends on phpspreadsheet `^5.3` but has no stable release, so there's no supported path to PHP 8.5 on a stable version. This PR fixes all hard 8.5 deprecations and widens the phpspreadsheet constraint to `^1.30.0 || ^2.0`.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No. All changes serve one goal: PHP 8.5 compatibility.

3️⃣  Does it include tests, if possible?

The `setAccessible()` fix is itself in test code. The conditional class loading and constraint change are structural; validated by the existing test suite. No new test logic needed.

4️⃣  Any drawbacks? Possible breaking changes?

No breaking changes to Laravel-Excel itself.

**Note for downstream subclasses:** `composer update` will resolve phpspreadsheet 2.0 (the newest stable version satisfying `^1.30.0 || ^2.0`). The conditional class loading handles this, but any downstream class extending `DefaultValueBinder`, `ChunkReadFilter`, or `LimitFilter` that overrides `bindValue()`/`readCell()` **without** `: bool` will get a fatal error — same as implementing `IReadFilter`/`IValueBinder` directly. The lockfile protects `composer install`; PHP 8.5 users are unaffected since phpspreadsheet 1.x blocks 8.5 anyway.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Validated by existing test suite (no new test logic needed; see 3️⃣).

6️⃣  Thanks for contributing! 🙌

Thanks for maintaining this package!

---

<details>
<summary>PHP 8.5 deprecation audit</summary>

Checked every deprecation from [php.net/migration85.deprecated](https://www.php.net/manual/en/migration85.deprecated.php).

**Fixed:**

| Deprecation | Location | Fix |
|---|---|---|
| `++$string` on non-numeric strings | `Sheet::buildColumnRange()` | `str_increment()` with `function_exists` fallback (cherry-picked from #4334; adjusted `@callable` → `@var` docblock tag) |
| `ReflectionMethod::setAccessible()` | `RowValidatorTest::callPrivateMethod()` | Guarded behind `PHP_VERSION_ID < 80100` |

**Soft deprecations (not addressed):** `__sleep()`/`__wakeup()` in `Reader.php`, `BatchCache.php`, `BatchCacheDeprecated.php`, `RemoteTemporaryFile.php` (`__sleep` only).

**Not present:** non-canonical casts, backtick operator, `__debugInfo()` returning null, `case` with semicolon, closure binding edge cases, `null` as array offset, constant redeclaration, `PDO::MYSQL_*`/`SQLITE_*`/`PGSQL_*` driver constants, `mysqli_execute()`, `SplObjectStorage::contains/attach/detach`, `socket_set_timeout`, `$http_response_header`, `DATE_RFC7231`, resource-freeing functions, `MHASH_*` constants, `readdir`/`rewinddir`/`closedir` with null, `chr()` outside [0,255], `ord()` with multi-byte strings. `ArrayIterator` appears in tests but is constructed with an array, not an object. INI/LDAP/OpenSSL/cURL-specific deprecations are N/A for library code.

</details>

<details>
<summary>phpspreadsheet 1.x → 2.0 compatibility audit</summary>

Per the [2.0.0 release notes](https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/2.0.0): strengthened native typing, removal of deprecated APIs ([816b91d](https://github.com/PHPOffice/PhpSpreadsheet/commit/816b91d0b4a0c7285a9e3fc88c58f7730d922044)), behavioral changes, and a PHP 8.0+ floor.

**Typing** — phpspreadsheet 2.0 added `: bool` return types to `IReadFilter::readCell()` and `IValueBinder::bindValue()`. Simply adding `: bool` would break downstream subclasses that override without it. Instead, each affected file uses conditional class loading: a `ReflectionMethod::hasReturnType()` check at class-load time selects the right definition. Shared properties/constructors live in per-file traits (`ChunkReadFilterBase`, `LimitFilterBase`); `DefaultValueBinder` inherits from the parent class so needs no trait. Parameters are left untyped in both branches (valid contravariance with 2.0).

| Class | Method | 1.30.x | 2.0 |
|---|---|---|---|
| `Filters\LimitFilter` | `readCell()` | no return type | `: bool` |
| `Filters\ChunkReadFilter` | `readCell()` | no return type | `: bool` |
| `DefaultValueBinder` | `bindValue()` | no return type | `: bool` |

**Removed deprecated APIs** — none used: `*ByColumnAndRow()` family, `Calculation\Database`/`DateTime`/`Engineering`/`Financial`, `Functions::null()`/`NAN()`/etc., `$suppressFormulaErrors`, `setIsUrl()`, `setLibXmlLoaderOptions()`, `getHashCode()`, `getProtectedCells()`, `SKIP_EMPTY_CELLS`, `ColorMap`, `JAMA`.

**Behavioral changes** — `toFormattedString()` now always returns `string` (used in `Cell.php`, stricter type is safer). `FORMAT_CURRENCY_EUR` value changed (only constant used; version check updated). HTML comment sanitization not referenced.

**PHP version floor** — phpspreadsheet 2.x requires PHP 8.0+. Composer resolves automatically: PHP 7.x gets 1.30.x.

</details>
